### PR TITLE
refactor(types): tighten TUploadResult default from any to unknown

### DIFF
--- a/docs/content/2.usage/1.overview.md
+++ b/docs/content/2.usage/1.overview.md
@@ -256,12 +256,12 @@ uploader.addPlugin(
 Each file in the `files` array has the following structure:
 
 ```ts
-interface UploadFile {
+interface UploadFile<TUploadResult = unknown> {
   id: string // Unique identifier
   name: string // Original filename
   size: number // Size in bytes
   mimeType: string // MIME type
-  status: FileStatus // 'waiting' | 'preprocessing' | 'uploading' | 'complete' | 'error'
+  status: FileStatus // 'waiting' | 'preprocessing' | 'uploading' | 'postprocessing' | 'complete' | 'error'
   source: FileSource // 'local' | 'storage' | etc.
   progress: {
     percentage: number // 0-100

--- a/docs/content/2.usage/1.overview.md
+++ b/docs/content/2.usage/1.overview.md
@@ -269,7 +269,7 @@ interface UploadFile {
   preview?: string // Thumbnail/preview URL
   remoteUrl?: string // URL after upload
   error?: FileError // Error details if failed
-  uploadResult?: any // Result from upload function
+  uploadResult?: TUploadResult // Result from upload function (typed when storage adapter is provided)
   meta: Record<string, unknown> // Custom metadata
   data: File | Blob | null // File data (null for remote files)
 }

--- a/docs/content/4.storage-adapters/2.azure-datalake.md
+++ b/docs/content/4.storage-adapters/2.azure-datalake.md
@@ -234,8 +234,8 @@ Access it after upload:
 ```ts
 uploader.on("upload:complete", (files) => {
   files.forEach((file) => {
-    console.log("Uploaded to:", file.uploadResult.url)
-    console.log("Storage key:", file.uploadResult.storageKey)
+    console.log("Uploaded to:", file.uploadResult?.url)
+    console.log("Storage key:", file.uploadResult?.storageKey)
   })
 })
 ```

--- a/docs/content/4.storage-adapters/5.firebase-storage.md
+++ b/docs/content/4.storage-adapters/5.firebase-storage.md
@@ -222,7 +222,7 @@ const uploader = useUploadKit({
 // Listen for uploads
 uploader.on("upload:complete", (files) => {
   files.forEach((file) => {
-    console.log("Uploaded:", file.uploadResult.url)
+    console.log("Uploaded:", file.uploadResult?.url)
   })
 })
 ```

--- a/docs/content/5.advanced/3.custom-storage-adapters.md
+++ b/docs/content/5.advanced/3.custom-storage-adapters.md
@@ -236,8 +236,8 @@ const uploader = useUploadKit({
 // After upload, access the result
 uploader.on("upload:complete", (files) => {
   files.forEach((file) => {
-    console.log("File URL:", file.uploadResult.url)
-    console.log("File ID:", file.uploadResult.id)
+    console.log("File URL:", file.uploadResult?.url)
+    console.log("File ID:", file.uploadResult?.id)
   })
 })
 ```

--- a/src/runtime/composables/useUploadKit/file-operations.ts
+++ b/src/runtime/composables/useUploadKit/file-operations.ts
@@ -3,7 +3,7 @@ import type { Emitter } from "mitt"
 import type { UploadFile, LocalUploadFile, UploadOptions, StoragePlugin, PluginLifecycleStage } from "./types"
 import { cleanupObjectURLs, createPluginContext } from "./utils"
 
-export interface FileOperationsDeps<TUploadResult = any> {
+export interface FileOperationsDeps<TUploadResult = unknown> {
   /** Reactive ref containing the files array */
   files: Ref<UploadFile<TUploadResult>[]>
   /** Event emitter for file events */
@@ -28,7 +28,7 @@ export interface FileOperationsDeps<TUploadResult = any> {
  * This factory function creates all file access and manipulation operations
  * with proper closure over the composable's internal state.
  */
-export function createFileOperations<TUploadResult = any>(deps: FileOperationsDeps<TUploadResult>) {
+export function createFileOperations<TUploadResult = unknown>(deps: FileOperationsDeps<TUploadResult>) {
   const { files, emitter, options, createdObjectURLs, getStoragePlugin, runPluginStage, upload, setHasEmittedFilesUploaded } =
     deps
 
@@ -156,7 +156,7 @@ export function createFileOperations<TUploadResult = any>(deps: FileOperationsDe
 
     // Re-run preprocess hooks to regenerate thumbnails/previews with new data
     const preprocessedFile = await runPluginStage("preprocess", updatedFile)
-    const finalFile = preprocessedFile || updatedFile
+    const finalFile = (preprocessedFile || updatedFile) as UploadFile<TUploadResult>
 
     // Update the file in the array
     const index = files.value.findIndex((f) => f.id === fileId)

--- a/src/runtime/composables/useUploadKit/index.ts
+++ b/src/runtime/composables/useUploadKit/index.ts
@@ -1,5 +1,6 @@
 import mitt from "mitt"
 import { computed, onBeforeUnmount, readonly, ref } from "vue"
+import type { Ref } from "vue"
 import type {
   UploaderEvents,
   UploadFile,
@@ -30,9 +31,11 @@ const defaultOptions: UploadOptions = {
   autoUpload: false,
 }
 
-export const useUploadKit = <TUploadResult = any>(_options: UploadOptions = {}) => {
+export const useUploadKit = <TUploadResult = unknown>(
+  _options: Omit<UploadOptions, "storage"> & { storage?: StoragePlugin<TUploadResult, any> } = {},
+) => {
   const options = { ...defaultOptions, ..._options } as UploadOptions
-  const files = ref<UploadFile<TUploadResult>[]>([])
+  const files = ref<UploadFile<TUploadResult>[]>([]) as Ref<UploadFile<TUploadResult>[]>
   const emitter = mitt<any>()
   const status = ref<UploadStatus>("waiting")
   const isReady = ref(options.initialFiles === undefined)
@@ -46,8 +49,8 @@ export const useUploadKit = <TUploadResult = any>(_options: UploadOptions = {}) 
   /**
    * Get the active storage plugin
    */
-  const getStoragePlugin = (): StoragePlugin<any, any> | null => {
-    return options.storage || null
+  const getStoragePlugin = (): StoragePlugin<TUploadResult, any> | null => {
+    return (options.storage as StoragePlugin<TUploadResult, any> | undefined) || null
   }
 
   const addPlugin = (plugin: UploaderPlugin<any, any>) => {
@@ -129,7 +132,9 @@ export const useUploadKit = <TUploadResult = any>(_options: UploadOptions = {}) 
   })
 
   const updateFile = (fileId: string, updatedFile: Partial<UploadFile<TUploadResult>>) => {
-    files.value = files.value.map((file) => (file.id === fileId ? ({ ...file, ...updatedFile } as UploadFile) : file))
+    files.value = files.value.map((file) =>
+      file.id === fileId ? ({ ...file, ...updatedFile } as UploadFile<TUploadResult>) : file,
+    )
   }
 
   /**
@@ -137,7 +142,8 @@ export const useUploadKit = <TUploadResult = any>(_options: UploadOptions = {}) 
    */
   const resolveRemoteFiles = async (initialFiles: InitialFileInput[]): Promise<UploadFile<TUploadResult>[]> => {
     const storagePlugin = getStoragePlugin()
-    if (!storagePlugin?.hooks.getRemoteFile) {
+    const getRemoteFile = storagePlugin?.hooks.getRemoteFile
+    if (!storagePlugin || !getRemoteFile) {
       throw new Error("Storage plugin with getRemoteFile hook is required to resolve remote files")
     }
 
@@ -147,7 +153,7 @@ export const useUploadKit = <TUploadResult = any>(_options: UploadOptions = {}) 
         if (!storageKey) return null
 
         const context = createPluginContext(storagePlugin.id, files.value, options, emitter, storagePlugin)
-        const remoteFileData = await storagePlugin.hooks.getRemoteFile(storageKey, context)
+        const remoteFileData = await getRemoteFile(storageKey, context)
 
         const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`
         const name = storageKey.split("/").pop() || storageKey
@@ -233,7 +239,7 @@ export const useUploadKit = <TUploadResult = any>(_options: UploadOptions = {}) 
       }
 
       const preprocessedFile = await runPluginStage("preprocess", validatedFile)
-      const fileToAdd = preprocessedFile || validatedFile
+      const fileToAdd = (preprocessedFile || validatedFile) as UploadFile<TUploadResult>
 
       files.value.push(fileToAdd)
       emitter.emit("file:added", fileToAdd)
@@ -247,7 +253,7 @@ export const useUploadKit = <TUploadResult = any>(_options: UploadOptions = {}) 
       return validatedFile
     } catch (err) {
       const error = createFileError(uploadFile, err)
-      const fileWithError = { ...uploadFile, status: "error" as const, error }
+      const fileWithError = { ...uploadFile, status: "error" as const, error } as UploadFile<TUploadResult>
       files.value.push(fileWithError)
       emitter.emit("file:error", { file: fileWithError, error })
       throw err
@@ -286,7 +292,7 @@ export const useUploadKit = <TUploadResult = any>(_options: UploadOptions = {}) 
     }
 
     if (processedFile.id !== file.id) {
-      files.value = files.value.map((f) => (f.id === file.id ? processedFile : f))
+      files.value = files.value.map((f) => (f.id === file.id ? (processedFile as UploadFile<TUploadResult>) : f))
     }
 
     updateFile(processedFile.id, { status: "uploading" })

--- a/src/runtime/composables/useUploadKit/plugin-runner.ts
+++ b/src/runtime/composables/useUploadKit/plugin-runner.ts
@@ -14,7 +14,7 @@ import type {
 
 type EmitFn = <K extends string | number | symbol>(event: K, payload: any) => void
 
-export interface PluginRunnerDeps<TUploadResult = any> {
+export interface PluginRunnerDeps<TUploadResult = unknown> {
   options: UploadOptions
   files: Ref<UploadFile<TUploadResult>[]>
   emitter: Emitter<any>
@@ -28,7 +28,7 @@ export interface PluginRunnerDeps<TUploadResult = any> {
  * - For 100 files × 5 plugins = 500+ function allocations without caching
  * - With caching: Only 5 function allocations total
  */
-export function createPluginRunner<TUploadResult = any>(deps: PluginRunnerDeps<TUploadResult>) {
+export function createPluginRunner<TUploadResult = unknown>(deps: PluginRunnerDeps<TUploadResult>) {
   const { options, files, emitter, getStoragePlugin } = deps
 
   // Cache for plugin emit functions

--- a/src/runtime/composables/useUploadKit/types.ts
+++ b/src/runtime/composables/useUploadKit/types.ts
@@ -36,7 +36,7 @@ export type FileSource = "local" | "storage" | "instagram" | "dropbox" | "google
 /**
  * Base properties shared by both local and remote upload files
  */
-export interface BaseUploadFile<TUploadResult = any> {
+export interface BaseUploadFile<TUploadResult = unknown> {
   /** Unique identifier for the file (stable, never changes after creation) */
   id: string
 
@@ -130,7 +130,7 @@ export interface BaseUploadFile<TUploadResult = any> {
  * }
  * ```
  */
-export interface LocalUploadFile<TUploadResult = any> extends BaseUploadFile<TUploadResult> {
+export interface LocalUploadFile<TUploadResult = unknown> extends BaseUploadFile<TUploadResult> {
   /** Always 'local' for files selected from user's device */
   source: "local"
 
@@ -168,7 +168,7 @@ export interface LocalUploadFile<TUploadResult = any> extends BaseUploadFile<TUp
  * }
  * ```
  */
-export interface RemoteUploadFile<TUploadResult = any> extends BaseUploadFile<TUploadResult> {
+export interface RemoteUploadFile<TUploadResult = unknown> extends BaseUploadFile<TUploadResult> {
   /**
    * Source of the remote file
    * - 'storage': File from your storage (previously uploaded)
@@ -204,7 +204,7 @@ export interface RemoteUploadFile<TUploadResult = any> extends BaseUploadFile<TU
  * }
  * ```
  */
-export type UploadFile<TUploadResult = any> = LocalUploadFile<TUploadResult> | RemoteUploadFile<TUploadResult>
+export type UploadFile<TUploadResult = unknown> = LocalUploadFile<TUploadResult> | RemoteUploadFile<TUploadResult>
 
 // Configuration
 export interface UploadOptions {
@@ -349,7 +349,7 @@ export interface ImageCompressionOptions {
 }
 
 // Core events (always available)
-type CoreUploaderEvents<TUploadResult = any> = {
+type CoreUploaderEvents<TUploadResult = unknown> = {
   "file:added": Readonly<UploadFile<TUploadResult>>
   "file:removed": Readonly<UploadFile<TUploadResult>>
   "file:replaced": Readonly<UploadFile<TUploadResult>>
@@ -369,7 +369,7 @@ type CoreUploaderEvents<TUploadResult = any> = {
 }
 
 // Events for listening - only core events are typed, plugins can emit arbitrary events
-export type UploaderEvents<TUploadResult = any> = CoreUploaderEvents<TUploadResult>
+export type UploaderEvents<TUploadResult = unknown> = CoreUploaderEvents<TUploadResult>
 
 /**
  * PLUGIN API - Types for building custom plugins
@@ -421,7 +421,7 @@ export type SetupHook<TPluginEvents extends Record<string, any> = Record<string,
  * }
  * ```
  */
-export type UploadHook<TUploadResult = any, TPluginEvents extends Record<string, any> = Record<string, never>> = (
+export type UploadHook<TUploadResult = unknown, TPluginEvents extends Record<string, any> = Record<string, never>> = (
   file: UploadFile<TUploadResult>,
   context: PluginContext<TPluginEvents> & { onProgress: (progress: number) => void },
 ) => Promise<
@@ -433,10 +433,10 @@ export type UploadHook<TUploadResult = any, TPluginEvents extends Record<string,
   }
 >
 
-export type GetRemoteFileHook<TPluginEvents extends Record<string, any> = Record<string, never>> = (
+export type GetRemoteFileHook<TUploadResult = unknown, TPluginEvents extends Record<string, any> = Record<string, never>> = (
   fileId: string,
   context: PluginContext<TPluginEvents>,
-) => Promise<MinimumRemoteFileAttributes>
+) => Promise<MinimumRemoteFileAttributes<TUploadResult>>
 
 export type RemoveHook<TPluginEvents extends Record<string, any> = Record<string, never>> = (
   file: UploadFile,
@@ -458,21 +458,21 @@ export type ProcessingPluginHooks<TPluginEvents extends Record<string, any> = Re
 /**
  * Storage plugin hooks (upload, download, delete from remote storage)
  */
-export type StoragePluginHooks<TUploadResult = any, TPluginEvents extends Record<string, any> = Record<string, never>> = {
+export type StoragePluginHooks<TUploadResult = unknown, TPluginEvents extends Record<string, any> = Record<string, never>> = {
   upload: UploadHook<TUploadResult, TPluginEvents>
-  getRemoteFile?: GetRemoteFileHook<TPluginEvents>
+  getRemoteFile?: GetRemoteFileHook<TUploadResult, TPluginEvents>
   remove?: RemoveHook<TPluginEvents>
 }
 
 /**
  * All possible plugin hooks (for internal use)
  */
-export type PluginHooks<TUploadResult = any, TPluginEvents extends Record<string, any> = Record<string, never>> = {
+export type PluginHooks<TUploadResult = unknown, TPluginEvents extends Record<string, any> = Record<string, never>> = {
   validate?: ValidationHook<TPluginEvents>
   preprocess?: ProcessingHook<TPluginEvents>
   process?: ProcessingHook<TPluginEvents>
   upload?: UploadHook<TUploadResult, TPluginEvents>
-  getRemoteFile?: GetRemoteFileHook<TPluginEvents>
+  getRemoteFile?: GetRemoteFileHook<TUploadResult, TPluginEvents>
   remove?: RemoveHook<TPluginEvents>
   complete?: ProcessingHook<TPluginEvents>
 }
@@ -482,7 +482,7 @@ export type PluginHooks<TUploadResult = any, TPluginEvents extends Record<string
  *
  * These plugins transform or validate files without handling storage.
  */
-export interface ProcessingPlugin<_TUploadResult = any, TPluginEvents extends Record<string, any> = Record<string, never>> {
+export interface ProcessingPlugin<_TUploadResult = unknown, TPluginEvents extends Record<string, any> = Record<string, never>> {
   id: string
   hooks: ProcessingPluginHooks<TPluginEvents>
   options?: UploadOptions
@@ -495,7 +495,7 @@ export interface ProcessingPlugin<_TUploadResult = any, TPluginEvents extends Re
  * Storage plugins handle uploading, downloading, and deleting files from remote storage.
  * Only one storage plugin can be active at a time.
  */
-export interface StoragePlugin<TUploadResult = any, TPluginEvents extends Record<string, any> = Record<string, never>> {
+export interface StoragePlugin<TUploadResult = unknown, TPluginEvents extends Record<string, any> = Record<string, never>> {
   id: string
   hooks: StoragePluginHooks<TUploadResult, TPluginEvents>
   options?: UploadOptions
@@ -540,7 +540,7 @@ export interface StoragePlugin<TUploadResult = any, TPluginEvents extends Record
 /**
  * Base plugin interface (for internal use - supports both types)
  */
-export interface Plugin<TUploadResult = any, TPluginEvents extends Record<string, any> = Record<string, never>> {
+export interface Plugin<TUploadResult = unknown, TPluginEvents extends Record<string, any> = Record<string, never>> {
   id: string
   hooks: PluginHooks<TUploadResult, TPluginEvents>
   options?: UploadOptions
@@ -601,7 +601,7 @@ export function defineProcessingPlugin<
  */
 export function defineStorageAdapter<
   TPluginOptions = unknown,
-  TUploadResult = any,
+  TUploadResult = unknown,
   TPluginEvents extends Record<string, any> = Record<string, never>,
 >(
   factory: (options: TPluginOptions) => StoragePlugin<TUploadResult, TPluginEvents>,
@@ -689,7 +689,7 @@ export interface UploadBlob {
   blobPath: string
 }
 
-export type MinimumRemoteFileAttributes<TUploadResult = any> = {
+export type MinimumRemoteFileAttributes<TUploadResult = unknown> = {
   size: number
   mimeType: string
   remoteUrl: string

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -33,7 +33,9 @@ export function createMockBlob(size: number = 1024, type: string = "image/jpeg")
 /**
  * Create a mock LocalUploadFile for testing
  */
-export function createMockLocalUploadFile(overrides: Partial<LocalUploadFile> & { storageKey?: string } = {}): LocalUploadFile {
+export function createMockLocalUploadFile<TUploadResult = unknown>(
+  overrides: Partial<LocalUploadFile<TUploadResult>> & { storageKey?: string } = {},
+): LocalUploadFile<TUploadResult> {
   const file = createMockFile(overrides.name || "test-file.jpg", overrides.size || 1024, overrides.mimeType || "image/jpeg")
 
   const { storageKey, ...rest } = overrides
@@ -56,7 +58,9 @@ export function createMockLocalUploadFile(overrides: Partial<LocalUploadFile> & 
 /**
  * Create a mock RemoteUploadFile for testing
  */
-export function createMockRemoteUploadFile(overrides: Partial<RemoteUploadFile> = {}): RemoteUploadFile {
+export function createMockRemoteUploadFile<TUploadResult = unknown>(
+  overrides: Partial<RemoteUploadFile<TUploadResult>> = {},
+): RemoteUploadFile<TUploadResult> {
   return {
     id: `${Date.now()}-${Math.random().toString(36).slice(2)}.jpg`,
     name: "remote-file.jpg",
@@ -216,7 +220,7 @@ export function createMockStoragePlugin(options?: {
     hooks: {
       upload: vi.fn(async (file: UploadFile, context: { onProgress: (p: number) => void }) => {
         const result = await uploadFn(file, context.onProgress)
-        return result
+        return result as { url: string; storageKey: string }
       }),
       getRemoteFile: vi.fn(async (storageKey: string) => getRemoteFileFn(storageKey)),
       ...(removeFn ? { remove: vi.fn(async (file: UploadFile) => removeFn(file)) } : {}),

--- a/test/unit/providers/firebase-storage.test.ts
+++ b/test/unit/providers/firebase-storage.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 
 import { createMockPluginContext, createMockRemoteUploadFile } from "../../helpers"
-import { PluginFirebaseStorage } from "../../../src/runtime/composables/useUploadKit/plugins/storage/firebase-storage"
+import {
+  PluginFirebaseStorage,
+  type FirebaseStorageUploadResult,
+} from "../../../src/runtime/composables/useUploadKit/plugins/storage/firebase-storage"
 
 // Mock Firebase Storage SDK - vi.mock is hoisted so we define everything inline
 vi.mock("firebase/storage", () => ({
@@ -120,7 +123,7 @@ describe("providers", () => {
           storage: mockStorage,
         })
 
-        const remoteFile = createMockRemoteUploadFile()
+        const remoteFile = createMockRemoteUploadFile<FirebaseStorageUploadResult>()
         const context = {
           ...createMockPluginContext(),
           onProgress: vi.fn(),

--- a/test/unit/providers/s3.test.ts
+++ b/test/unit/providers/s3.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { createMockPluginContext, createMockLocalUploadFile, createMockRemoteUploadFile } from "../../helpers"
-import { PluginS3 } from "../../../src/runtime/composables/useUploadKit/plugins/storage/s3"
+import { PluginS3, type S3UploadResult } from "../../../src/runtime/composables/useUploadKit/plugins/storage/s3"
 
 // Factory to create mock XHR instances
 function createMockXHR() {
@@ -116,7 +116,7 @@ describe("providers", () => {
           getPresignedUploadUrl: vi.fn(),
         })
 
-        const remoteFile = createMockRemoteUploadFile()
+        const remoteFile = createMockRemoteUploadFile<S3UploadResult>()
         const context = {
           ...createMockPluginContext(),
           onProgress: vi.fn(),
@@ -135,7 +135,7 @@ describe("providers", () => {
 
         const plugin = PluginS3({ getPresignedUploadUrl })
 
-        const file = createMockLocalUploadFile({
+        const file = createMockLocalUploadFile<S3UploadResult>({
           id: "test-file-id",
           name: "test.jpg",
           size: 1024,
@@ -163,7 +163,7 @@ describe("providers", () => {
 
         const plugin = PluginS3({ getPresignedUploadUrl })
 
-        const file = createMockLocalUploadFile({ id: "my-file-id" })
+        const file = createMockLocalUploadFile<S3UploadResult>({ id: "my-file-id" })
         const context = {
           ...createMockPluginContext(),
           onProgress: vi.fn(),
@@ -188,7 +188,7 @@ describe("providers", () => {
           path: "uploads/images",
         })
 
-        const file = createMockLocalUploadFile({ id: "my-file-id.jpg" })
+        const file = createMockLocalUploadFile<S3UploadResult>({ id: "my-file-id.jpg" })
         const context = {
           ...createMockPluginContext(),
           onProgress: vi.fn(),
@@ -487,7 +487,7 @@ describe("providers", () => {
         })
 
         const plugin = PluginS3({ getPresignedUploadUrl })
-        const file = createMockLocalUploadFile()
+        const file = createMockLocalUploadFile<S3UploadResult>()
         const context = {
           ...createMockPluginContext(),
           onProgress: vi.fn(),
@@ -505,7 +505,7 @@ describe("providers", () => {
         })
 
         const plugin = PluginS3({ getPresignedUploadUrl })
-        const file = createMockLocalUploadFile({ mimeType: "image/png" })
+        const file = createMockLocalUploadFile<S3UploadResult>({ mimeType: "image/png" })
         const context = {
           ...createMockPluginContext(),
           onProgress: vi.fn(),

--- a/test/unit/useUploadKit.test.ts
+++ b/test/unit/useUploadKit.test.ts
@@ -1209,8 +1209,8 @@ describe("useUploadKit", () => {
     /**
      * Helper to wait for initialFiles to load (event-based, more deterministic than wait())
      */
-    const waitForInitialFiles = (
-      uploader: ReturnType<typeof useUploadKit>,
+    const waitForInitialFiles = <T>(
+      uploader: ReturnType<typeof useUploadKit<T>>,
       options: { expectError?: boolean; timeout?: number } = {},
     ) => {
       const { expectError = false, timeout = 1000 } = options


### PR DESCRIPTION
Closes #151

## Summary
- Flip `TUploadResult = any` defaults to `unknown` across the type system, removing implicit `any` from `UploadFile`, hooks, and plugin types
- `useUploadKit` now infers `TUploadResult` from the storage plugin (e.g. `useUploadKit({ storage: PluginS3(...) })` types `file.uploadResult` as `S3UploadResult` automatically) — explicit `useUploadKit<T>()` is still supported
- Make `GetRemoteFileHook` generic so `getRemoteFile` returns properly-typed `MinimumRemoteFileAttributes<T>`
- Update test helpers (`createMockLocalUploadFile`, `createMockRemoteUploadFile`) to be generic and update doc examples to use optional chaining on `file.uploadResult`

## Test plan
- [x] `pnpm test` — all 380 tests pass
- [x] `pnpm test:types` — no new type errors (pre-existing count unchanged)
- [x] `pnpm lint` — clean
- [x] Verified inference end-to-end with type-level checks: inline storage, storage variable, no storage, and explicit generic all resolve correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Examples updated to safely access upload result properties (uses optional-safe access), avoiding runtime errors when results are absent.
  * Clarified upload-file docs to include a new 'postprocessing' status phase.

* **Refactor**
  * Tightened upload-result typing to a generic/unknown default, improving type safety across the library.

* **Tests**
  * Tests and test helpers updated to align with the refined upload-result typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->