### PR TITLE
refactor(types): type mitt emitter with UploaderEvents

### DIFF
--- a/src/runtime/composables/useUploadKit/file-operations.ts
+++ b/src/runtime/composables/useUploadKit/file-operations.ts
@@ -1,13 +1,12 @@
 import type { Ref } from "vue"
-import type { Emitter } from "mitt"
-import type { UploadFile, LocalUploadFile, UploadOptions, StoragePlugin, PluginLifecycleStage } from "./types"
+import type { UploadFile, LocalUploadFile, UploadOptions, StoragePlugin, PluginLifecycleStage, UploaderEmitter } from "./types"
 import { cleanupObjectURLs, createPluginContext } from "./utils"
 
 export interface FileOperationsDeps<TUploadResult = unknown> {
   /** Reactive ref containing the files array */
   files: Ref<UploadFile<TUploadResult>[]>
   /** Event emitter for file events */
-  emitter: Emitter<any>
+  emitter: UploaderEmitter<TUploadResult>
   /** Upload options configuration */
   options: UploadOptions
   /** Map tracking created object URLs for cleanup */
@@ -15,7 +14,10 @@ export interface FileOperationsDeps<TUploadResult = unknown> {
   /** Function to get the active storage plugin */
   getStoragePlugin: () => StoragePlugin<any, any> | null
   /** Function to run plugin lifecycle stages */
-  runPluginStage: (stage: Exclude<PluginLifecycleStage, "upload">, file?: UploadFile) => Promise<UploadFile | undefined | null>
+  runPluginStage: (
+    stage: Exclude<PluginLifecycleStage, "upload">,
+    file?: UploadFile<TUploadResult>,
+  ) => Promise<UploadFile<TUploadResult> | undefined | null>
   /** Function to trigger upload */
   upload: () => Promise<void>
   /** Function to update the hasEmittedFilesUploaded flag */
@@ -142,7 +144,7 @@ export function createFileOperations<TUploadResult = unknown>(deps: FileOperatio
     cleanupObjectURLs(createdObjectURLs, fileId)
 
     // Convert to LocalUploadFile since we now have local data
-    const updatedFile: LocalUploadFile = {
+    const updatedFile: LocalUploadFile<TUploadResult> = {
       ...file,
       source: "local",
       data: newData,
@@ -155,8 +157,7 @@ export function createFileOperations<TUploadResult = unknown>(deps: FileOperatio
     }
 
     // Re-run preprocess hooks to regenerate thumbnails/previews with new data
-    const preprocessedFile = await runPluginStage("preprocess", updatedFile)
-    const finalFile = (preprocessedFile || updatedFile) as UploadFile<TUploadResult>
+    const finalFile = (await runPluginStage("preprocess", updatedFile)) || updatedFile
 
     // Update the file in the array
     const index = files.value.findIndex((f) => f.id === fileId)

--- a/src/runtime/composables/useUploadKit/index.ts
+++ b/src/runtime/composables/useUploadKit/index.ts
@@ -2,13 +2,12 @@ import mitt from "mitt"
 import { computed, onBeforeUnmount, readonly, ref } from "vue"
 import type { Ref } from "vue"
 import type {
-  UploaderEvents,
+  UploaderEmitter,
   UploadFile,
   LocalUploadFile,
   RemoteUploadFile,
   UploadOptions,
   UploadStatus,
-  FileError,
   Plugin as UploaderPlugin,
   ProcessingPlugin,
   StoragePlugin,
@@ -36,7 +35,7 @@ export const useUploadKit = <TUploadResult = unknown>(
 ) => {
   const options = { ...defaultOptions, ..._options } as UploadOptions
   const files = ref<UploadFile<TUploadResult>[]>([]) as Ref<UploadFile<TUploadResult>[]>
-  const emitter = mitt<any>()
+  const emitter: UploaderEmitter<TUploadResult> = mitt()
   const status = ref<UploadStatus>("waiting")
   const isReady = ref(options.initialFiles === undefined)
 
@@ -220,7 +219,7 @@ export const useUploadKit = <TUploadResult = unknown>(
     const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`
     const extension = getExtension(file.name)
 
-    const uploadFile: LocalUploadFile = {
+    const uploadFile: LocalUploadFile<TUploadResult> = {
       id: `${id}.${extension}`,
       progress: { percentage: 0 },
       name: file.name,
@@ -238,8 +237,7 @@ export const useUploadKit = <TUploadResult = unknown>(
         throw new Error(`File validation failed for ${file.name}`)
       }
 
-      const preprocessedFile = await runPluginStage("preprocess", validatedFile)
-      const fileToAdd = (preprocessedFile || validatedFile) as UploadFile<TUploadResult>
+      const fileToAdd = (await runPluginStage("preprocess", validatedFile)) || validatedFile
 
       files.value.push(fileToAdd)
       emitter.emit("file:added", fileToAdd)
@@ -253,7 +251,7 @@ export const useUploadKit = <TUploadResult = unknown>(
       return validatedFile
     } catch (err) {
       const error = createFileError(uploadFile, err)
-      const fileWithError = { ...uploadFile, status: "error" as const, error } as UploadFile<TUploadResult>
+      const fileWithError: UploadFile<TUploadResult> = { ...uploadFile, status: "error", error }
       files.value.push(fileWithError)
       emitter.emit("file:error", { file: fileWithError, error })
       throw err
@@ -263,7 +261,7 @@ export const useUploadKit = <TUploadResult = unknown>(
   const addFiles = async (newFiles: File[]) => {
     const results = await Promise.allSettled(newFiles.map((file) => addFile(file)))
     const addedFiles = results
-      .filter((r): r is PromiseFulfilledResult<UploadFile> => r.status === "fulfilled")
+      .filter((r): r is PromiseFulfilledResult<UploadFile<TUploadResult>> => r.status === "fulfilled")
       .map((r) => r.value)
     return addedFiles
   }
@@ -287,7 +285,7 @@ export const useUploadKit = <TUploadResult = unknown>(
     if (!processedFile) {
       const error = createFileError(file, new Error("File processing failed"))
       updateFile(file.id, { status: "error", error })
-      emitter.emit("file:error", { file, error } as { file: Readonly<UploadFile<TUploadResult>>; error: FileError })
+      emitter.emit("file:error", { file, error })
       return
     }
 
@@ -299,10 +297,7 @@ export const useUploadKit = <TUploadResult = unknown>(
 
     const onProgress = (progress: number) => {
       updateFile(processedFile.id, { progress: { percentage: progress } })
-      emitter.emit("upload:progress", { file: processedFile, progress } as {
-        file: Readonly<UploadFile<TUploadResult>>
-        progress: number
-      })
+      emitter.emit("upload:progress", { file: processedFile, progress })
     }
 
     const storagePlugin = getStoragePlugin()
@@ -334,25 +329,25 @@ export const useUploadKit = <TUploadResult = unknown>(
   const upload = async () => {
     const filesToUpload = files.value.filter((f) => f.status === "waiting")
 
-    emitter.emit("upload:start", filesToUpload as Array<Readonly<UploadFile<TUploadResult>>>)
+    emitter.emit("upload:start", filesToUpload)
 
     for (const file of filesToUpload) {
       try {
-        await uploadSingleFile(file as UploadFile<TUploadResult>)
+        await uploadSingleFile(file)
       } catch (err) {
-        const error = createFileError(file as UploadFile<TUploadResult>, err)
+        const error = createFileError(file, err)
         updateFile(file.id, { status: "error", error })
-        emitter.emit("file:error", { file, error } as { file: Readonly<UploadFile<TUploadResult>>; error: FileError })
+        emitter.emit("file:error", { file, error })
       }
     }
 
-    const completed = files.value.filter((f) => f.status === "complete")
-    emitter.emit("upload:complete", completed as Array<Required<Readonly<UploadFile<TUploadResult>>>>)
+    const completed = files.value.filter((f) => f.status === "complete") as Array<Required<UploadFile<TUploadResult>>>
+    emitter.emit("upload:complete", completed)
 
     const allComplete = files.value.length > 0 && files.value.every((f) => f.status === "complete")
     if (allComplete && !hasEmittedFilesUploaded) {
       hasEmittedFilesUploaded = true
-      emitter.emit("files:uploaded", files.value as Array<Readonly<UploadFile<TUploadResult>>>)
+      emitter.emit("files:uploaded", files.value)
     }
   }
 
@@ -407,9 +402,6 @@ export const useUploadKit = <TUploadResult = unknown>(
     addPlugin,
 
     // Events
-    on: emitter.on as {
-      <K extends keyof UploaderEvents<TUploadResult>>(type: K, handler: (event: UploaderEvents<TUploadResult>[K]) => void): void
-      (type: string, handler: (event: any) => void): void
-    },
+    on: emitter.on,
   }
 }

--- a/src/runtime/composables/useUploadKit/plugin-runner.ts
+++ b/src/runtime/composables/useUploadKit/plugin-runner.ts
@@ -1,5 +1,4 @@
 import type { Ref } from "vue"
-import type { Emitter } from "mitt"
 import type {
   UploadFile,
   UploadOptions,
@@ -10,6 +9,7 @@ import type {
   SetupHook,
   PluginContext,
   StoragePlugin,
+  UploaderEmitter,
 } from "./types"
 
 type EmitFn = <K extends string | number | symbol>(event: K, payload: any) => void
@@ -17,7 +17,7 @@ type EmitFn = <K extends string | number | symbol>(event: K, payload: any) => vo
 export interface PluginRunnerDeps<TUploadResult = unknown> {
   options: UploadOptions
   files: Ref<UploadFile<TUploadResult>[]>
-  emitter: Emitter<any>
+  emitter: UploaderEmitter<TUploadResult>
   getStoragePlugin: () => StoragePlugin<any, any> | null
 }
 
@@ -80,8 +80,8 @@ export function createPluginRunner<TUploadResult = unknown>(deps: PluginRunnerDe
    */
   async function runPluginStage(
     stage: Exclude<PluginLifecycleStage, "upload">,
-    file?: UploadFile,
-  ): Promise<UploadFile | undefined | null> {
+    file?: UploadFile<TUploadResult>,
+  ): Promise<UploadFile<TUploadResult> | undefined | null> {
     if (!options.plugins) return file
 
     let currentFile = file
@@ -102,7 +102,7 @@ export function createPluginRunner<TUploadResult = unknown>(deps: PluginRunnerDe
         const result = await callPluginHook(hook, stage, currentFile, context)
 
         if (result && currentFile && "id" in result) {
-          currentFile = result
+          currentFile = result as UploadFile<TUploadResult>
         }
       } catch (error) {
         if (currentFile) {

--- a/src/runtime/composables/useUploadKit/types.ts
+++ b/src/runtime/composables/useUploadKit/types.ts
@@ -372,6 +372,13 @@ type CoreUploaderEvents<TUploadResult = unknown> = {
 export type UploaderEvents<TUploadResult = unknown> = CoreUploaderEvents<TUploadResult>
 
 /**
+ * mitt emitter type used internally. Intersects core events with a string-keyed
+ * catch-all so plugin-namespaced events (`${pluginId}:${event}`) typecheck as `unknown`
+ * without losing the precise payload typing on core events.
+ */
+export type UploaderEmitter<TUploadResult = unknown> = Emitter<UploaderEvents<TUploadResult> & Record<string, unknown>>
+
+/**
  * PLUGIN API - Types for building custom plugins
  * Only needed if users want to create custom validators/processors
  */

--- a/src/runtime/composables/useUploadKit/utils.ts
+++ b/src/runtime/composables/useUploadKit/utils.ts
@@ -1,6 +1,13 @@
 import { isRef, toValue, watch } from "vue"
-import type { PluginContext, UploadFile, FileError, UploadOptions, InitialFileInput, StoragePlugin } from "./types"
-import type { Emitter } from "mitt"
+import type {
+  PluginContext,
+  UploadFile,
+  FileError,
+  UploadOptions,
+  InitialFileInput,
+  StoragePlugin,
+  UploaderEmitter,
+} from "./types"
 
 /**
  * Get file extension from filename
@@ -18,11 +25,11 @@ export function getExtension(fullFileName: string): string {
 /**
  * Create a plugin context object with consistent structure
  */
-export function createPluginContext<TPluginEvents extends Record<string, any> = Record<string, never>>(
+export function createPluginContext<TPluginEvents extends Record<string, any> = Record<string, never>, TUploadResult = unknown>(
   pluginId: string,
   files: UploadFile[],
   options: UploadOptions,
-  emitter: Emitter<any>,
+  emitter: UploaderEmitter<TUploadResult>,
   storage?: StoragePlugin<any, any>,
 ): PluginContext<TPluginEvents> {
   return {
@@ -30,7 +37,7 @@ export function createPluginContext<TPluginEvents extends Record<string, any> = 
     options,
     storage,
     emit: (event, payload) => {
-      const prefixedEvent = `${pluginId}:${String(event)}` as any
+      const prefixedEvent = `${pluginId}:${String(event)}`
       emitter.emit(prefixedEvent, payload)
     },
   }

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -9,11 +9,12 @@ import {
 } from "../../src/runtime/composables/useUploadKit/utils"
 import { createMockLocalUploadFile } from "../helpers"
 import mitt from "mitt"
+import type { UploaderEvents } from "../../src/runtime/composables/useUploadKit/types"
 
 describe("utils", () => {
   describe("createPluginContext", () => {
     it("should create a plugin context with all properties", () => {
-      const emitter = mitt()
+      const emitter = mitt<UploaderEvents & Record<string, unknown>>()
       const files = [createMockLocalUploadFile()]
       const options = { maxFiles: 10 }
 
@@ -25,7 +26,7 @@ describe("utils", () => {
     })
 
     it("should prefix emitted events with plugin ID", () => {
-      const emitter = mitt()
+      const emitter = mitt<UploaderEvents & Record<string, unknown>>()
       const handler = vi.fn()
       emitter.on("test-plugin:custom-event", handler)
 
@@ -36,7 +37,7 @@ describe("utils", () => {
     })
 
     it("should handle different plugin IDs", () => {
-      const emitter = mitt()
+      const emitter = mitt<UploaderEvents & Record<string, unknown>>()
       const handler1 = vi.fn()
       const handler2 = vi.fn()
 
@@ -54,14 +55,14 @@ describe("utils", () => {
     })
 
     it("should work with empty files array", () => {
-      const emitter = mitt()
+      const emitter = mitt<UploaderEvents & Record<string, unknown>>()
       const context = createPluginContext("test", [], {}, emitter)
 
       expect(context.files).toHaveLength(0)
     })
 
     it("should work with empty options", () => {
-      const emitter = mitt()
+      const emitter = mitt<UploaderEvents & Record<string, unknown>>()
       const context = createPluginContext("test", [], {}, emitter)
 
       expect(context.options).toEqual({})


### PR DESCRIPTION
## Summary

Closes #152 (and #153 as a side-effect).

Replaces `mitt<any>()` with a typed emitter via a new `UploaderEmitter<TUploadResult>` alias, intersected with `Record<string, unknown>` so plugin-namespaced events (`${pluginId}:${event}`) still typecheck. This removes 6 inline emit casts, the manual `on` overload, and the `files as any` cast in `createFileOperations` wiring by threading `TUploadResult` through `runPluginStage`, `createPluginContext`, and the `LocalUploadFile` constructions in `addFile` / `replaceFileData`.

## Test plan

- [x] `pnpm test` — 380/380 pass
- [x] `pnpm test:types` — same baseline error count as `master` (no new TS errors introduced)
- [x] `pnpm lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety throughout the upload system by introducing stronger generic type constraints and eliminating unnecessary type assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->