### PR TITLE
refactor!: rename initialize/appendExistingFiles to set/addExistingFiles

### DIFF
--- a/docs/content/2.usage/1.overview.md
+++ b/docs/content/2.usage/1.overview.md
@@ -83,7 +83,7 @@ Remove a file by ID. Optionally control whether to delete from remote storage.
 
 - `"always"` - Always delete from storage if the file has a `remoteUrl`
 - `"never"` - Never delete from storage, only remove from local state (useful for forms that reference shared files)
-- `"local-only"` - Only delete files uploaded in this session (`source === "local"`), preserving files loaded via `initializeExistingFiles`
+- `"local-only"` - Only delete files uploaded in this session (`source === "local"`), preserving files loaded via `setExistingFiles`
 
 ```ts
 // Default: removes from local state AND deletes from storage
@@ -206,16 +206,16 @@ uploader.reorderFile(0, 2) // Move first file to third position
 
 ### Initialization
 
-#### `initializeExistingFiles(files: InitialFileInput[]): Promise<void>`
+#### `setExistingFiles(files: InitialFileInput[]): Promise<void>`
 
 Load existing files (e.g., from a database) into the uploader. **Replaces** the current file list.
 
 ```ts
 // Load previously uploaded files
-await uploader.initializeExistingFiles([{ storageKey: "uploads/file-1.jpg" }, { storageKey: "uploads/file-2.png" }])
+await uploader.setExistingFiles([{ storageKey: "uploads/file-1.jpg" }, { storageKey: "uploads/file-2.png" }])
 ```
 
-#### `appendExistingFiles(files: InitialFileInput[]): Promise<UploadFile[]>`
+#### `addExistingFiles(files: InitialFileInput[]): Promise<UploadFile[]>`
 
 Append pre-existing remote files **without replacing** current files. Returns the files that were actually added.
 
@@ -225,7 +225,7 @@ Append pre-existing remote files **without replacing** current files. Returns th
 
 ```ts
 // User picks files from a media library — inject them into the upload manager
-const added = await uploader.appendExistingFiles([
+const added = await uploader.addExistingFiles([
   { storageKey: "library/photo-1.jpg" },
   { storageKey: "library/photo-2.jpg" },
 ])

--- a/docs/content/4.storage-adapters/2.azure-datalake.md
+++ b/docs/content/4.storage-adapters/2.azure-datalake.md
@@ -274,7 +274,7 @@ Load previously uploaded files:
 
 ```ts
 // The adapter's getRemoteFile hook fetches metadata from Azure
-await uploader.setExistingFiles([{ id: "path/to/file1.jpg" }, { id: "path/to/file2.png" }])
+await uploader.setExistingFiles([{ storageKey: "path/to/file1.jpg" }, { storageKey: "path/to/file2.png" }])
 ```
 
 ## Deleting Files

--- a/docs/content/4.storage-adapters/2.azure-datalake.md
+++ b/docs/content/4.storage-adapters/2.azure-datalake.md
@@ -274,7 +274,7 @@ Load previously uploaded files:
 
 ```ts
 // The adapter's getRemoteFile hook fetches metadata from Azure
-await uploader.initializeExistingFiles([{ id: "path/to/file1.jpg" }, { id: "path/to/file2.png" }])
+await uploader.setExistingFiles([{ id: "path/to/file1.jpg" }, { id: "path/to/file2.png" }])
 ```
 
 ## Deleting Files

--- a/docs/content/4.storage-adapters/5.firebase-storage.md
+++ b/docs/content/4.storage-adapters/5.firebase-storage.md
@@ -262,7 +262,7 @@ await uploader.removeFile(file.id)
 Load previously uploaded files:
 
 ```ts
-await uploader.initializeExistingFiles([
+await uploader.setExistingFiles([
   { id: "uploads/file1.jpg" },
   { id: "uploads/file2.png" },
 ])

--- a/docs/content/4.storage-adapters/5.firebase-storage.md
+++ b/docs/content/4.storage-adapters/5.firebase-storage.md
@@ -263,8 +263,8 @@ Load previously uploaded files:
 
 ```ts
 await uploader.setExistingFiles([
-  { id: "uploads/file1.jpg" },
-  { id: "uploads/file2.png" },
+  { storageKey: "uploads/file1.jpg" },
+  { storageKey: "uploads/file2.png" },
 ])
 ```
 

--- a/docs/content/5.advanced/4.lifecycle.md
+++ b/docs/content/5.advanced/4.lifecycle.md
@@ -181,7 +181,7 @@ Load files from your database:
 
 ```ts
 // Replaces the file list with these remote files
-await uploader.initializeExistingFiles([
+await uploader.setExistingFiles([
   { storageKey: "path/to/file1.jpg" },
   { storageKey: "path/to/file2.png" },
 ])
@@ -201,22 +201,22 @@ The storage plugin's `getRemoteFile` hook fetches metadata:
 
 ## Appending Existing Files
 
-Use `appendExistingFiles` when you need to add remote files **alongside** files the user has already selected — for example, when a user picks items from a media library:
+Use `addExistingFiles` when you need to add remote files **alongside** files the user has already selected — for example, when a user picks items from a media library:
 
 ```ts
 // User already added local files via file picker
 await uploader.addFiles(localFiles)
 
 // Later, user picks files from a media library
-const added = await uploader.appendExistingFiles([
+const added = await uploader.addExistingFiles([
   { storageKey: "library/photo-1.jpg" },
   { storageKey: "library/photo-2.jpg" },
 ])
 ```
 
-Key differences from `initializeExistingFiles`:
+Key differences from `setExistingFiles`:
 
-| | `initializeExistingFiles` | `appendExistingFiles` |
+| | `setExistingFiles` | `addExistingFiles` |
 |---|---|---|
 | **Behavior** | Replaces all files | Adds to existing files |
 | **Deduplication** | No | Skips files already present by `storageKey` |

--- a/src/runtime/composables/useUploadKit/file-operations.ts
+++ b/src/runtime/composables/useUploadKit/file-operations.ts
@@ -218,7 +218,7 @@ export function createFileOperations<TUploadResult = unknown>(deps: FileOperatio
    *   - `"always"` (default): Always delete from storage if the file has a remoteUrl
    *   - `"never"`: Never delete from storage, only remove from local state
    *   - `"local-only"`: Only delete files that were uploaded in this session (source === "local"),
-   *     preserving files that were loaded from storage via initializeExistingFiles
+   *     preserving files that were loaded from storage via setExistingFiles
    */
   const removeFile = async (
     fileId: string,

--- a/src/runtime/composables/useUploadKit/index.ts
+++ b/src/runtime/composables/useUploadKit/index.ts
@@ -262,16 +262,16 @@ export const useUploadKit = <TUploadResult = unknown>(
     return resolved.filter((f) => f !== null) as UploadFile<TUploadResult>[]
   }
 
-  const initializeExistingFiles = async (initialFiles: InitialFileInput[]) => {
+  const setExistingFiles = async (initialFiles: InitialFileInput[]) => {
     const resolvedFiles = await resolveRemoteFiles(initialFiles)
     files.value = [...resolvedFiles]
   }
 
   /**
-   * Append pre-existing remote files without replacing current files.
+   * Add pre-existing remote files without replacing current files.
    * Skips files already present (matched by storageKey) and respects maxFiles.
    */
-  const appendExistingFiles = async (initialFiles: InitialFileInput[]): Promise<UploadFile<TUploadResult>[]> => {
+  const addExistingFiles = async (initialFiles: InitialFileInput[]): Promise<UploadFile<TUploadResult>[]> => {
     // Deduplicate: skip files already present by storageKey
     const existingKeys = new Set(files.value.map((f) => f.storageKey).filter(Boolean))
     let filesToAdd = initialFiles.filter((f) => f.storageKey && !existingKeys.has(f.storageKey))
@@ -361,7 +361,7 @@ export const useUploadKit = <TUploadResult = unknown>(
     files,
     isReady,
     emitter,
-    initializeExistingFiles,
+    setExistingFiles,
   })
 
   return {
@@ -388,8 +388,8 @@ export const useUploadKit = <TUploadResult = unknown>(
     getFileStream: fileOps.getFileStream,
     replaceFileData: fileOps.replaceFileData,
     updateFile,
-    initializeExistingFiles,
-    appendExistingFiles,
+    setExistingFiles,
+    addExistingFiles,
 
     // Utilities
     addPlugin,

--- a/src/runtime/composables/useUploadKit/utils.ts
+++ b/src/runtime/composables/useUploadKit/utils.ts
@@ -142,13 +142,13 @@ export function setupInitialFiles<TUploadResult>({
   files,
   isReady,
   emitter,
-  initializeExistingFiles,
+  setExistingFiles,
 }: {
   initialFiles: UploadOptions["initialFiles"]
   files: { value: UploadFile<TUploadResult>[] }
   isReady: { value: boolean }
   emitter: { emit: (type: string, data: unknown) => void }
-  initializeExistingFiles: (files: InitialFileInput[]) => Promise<void>
+  setExistingFiles: (files: InitialFileInput[]) => Promise<void>
 }) {
   if (initialFiles === undefined) return
 
@@ -161,7 +161,7 @@ export function setupInitialFiles<TUploadResult>({
     if (paths.length > 0 && paths.every(Boolean)) {
       isInitialized = true
       try {
-        await initializeExistingFiles(paths.map((storageKey) => ({ storageKey })))
+        await setExistingFiles(paths.map((storageKey) => ({ storageKey })))
         isReady.value = true
         emitter.emit("initialFiles:loaded", files.value)
       } catch (error) {

--- a/test/unit/useUploadKit.test.ts
+++ b/test/unit/useUploadKit.test.ts
@@ -200,9 +200,9 @@ describe("useUploadKit", () => {
 
       const uploader = useUploadKit({ storage: storagePlugin })
 
-      // Add a remote file using initializeExistingFiles
+      // Add a remote file using setExistingFiles
       // The passed-in id becomes storageKey, file gets a generated id
-      await uploader.initializeExistingFiles([{ storageKey: "remote-1" }])
+      await uploader.setExistingFiles([{ storageKey: "remote-1" }])
 
       expect(uploader.files.value).toHaveLength(1)
       expect(uploader.files.value[0]!.remoteUrl).toBe("https://storage.example.com/remote-1.jpg")
@@ -235,8 +235,8 @@ describe("useUploadKit", () => {
 
       const uploader = useUploadKit({ storage: storagePlugin })
 
-      // Add a remote file using initializeExistingFiles
-      await uploader.initializeExistingFiles([{ storageKey: "remote-1" }])
+      // Add a remote file using setExistingFiles
+      await uploader.setExistingFiles([{ storageKey: "remote-1" }])
 
       // Use the generated file.id to remove
       const fileId = uploader.files.value[0]!.id
@@ -269,7 +269,7 @@ describe("useUploadKit", () => {
       const uploader = useUploadKit({ storage: storagePlugin })
 
       // Add a remote file (source: "storage") - simulates pre-populated file
-      await uploader.initializeExistingFiles([{ storageKey: "existing-file" }])
+      await uploader.setExistingFiles([{ storageKey: "existing-file" }])
       const remoteFileId = uploader.files.value[0]!.id
 
       // Add and upload a local file (source: "local")
@@ -751,7 +751,7 @@ describe("useUploadKit", () => {
     })
   })
 
-  describe("initializeExistingFiles", () => {
+  describe("setExistingFiles", () => {
     it("should initialize files from remote storage", async () => {
       const storage = createMockStoragePlugin({
         getRemoteFileFn: async (storageKey) => ({
@@ -762,7 +762,7 @@ describe("useUploadKit", () => {
       })
       const uploader = useUploadKit({ storage })
 
-      await uploader.initializeExistingFiles([{ storageKey: "remote-1.png" }, { storageKey: "remote-2.png" }])
+      await uploader.setExistingFiles([{ storageKey: "remote-1.png" }, { storageKey: "remote-2.png" }])
 
       expect(uploader.files.value).toHaveLength(2)
       expect(uploader.files.value[0]!.source).toBe("storage")
@@ -780,7 +780,7 @@ describe("useUploadKit", () => {
       })
       const uploader = useUploadKit({ storage })
 
-      await uploader.initializeExistingFiles([
+      await uploader.setExistingFiles([
         { storageKey: "valid.png" },
         { storageKey: "" }, // Empty storageKey
       ])
@@ -789,7 +789,7 @@ describe("useUploadKit", () => {
     })
   })
 
-  describe("appendExistingFiles", () => {
+  describe("addExistingFiles", () => {
     const defaultGetRemoteFileFn = async (storageKey: string) => ({
       size: 2048,
       mimeType: storageKey.endsWith(".png") ? "image/png" : "image/jpeg",
@@ -801,7 +801,7 @@ describe("useUploadKit", () => {
       const uploader = useUploadKit({ storage })
 
       await uploader.addFile(createMockFile("local.jpg"))
-      const added = await uploader.appendExistingFiles([{ storageKey: "remote-1.png" }, { storageKey: "remote-2.png" }])
+      const added = await uploader.addExistingFiles([{ storageKey: "remote-1.png" }, { storageKey: "remote-2.png" }])
 
       expect(added).toHaveLength(2)
       expect(uploader.files.value).toHaveLength(3)
@@ -833,7 +833,7 @@ describe("useUploadKit", () => {
       })
       const uploader = useUploadKit({ storage })
 
-      const added = await uploader.appendExistingFiles([{ storageKey: "photos/pic.webp" }])
+      const added = await uploader.addExistingFiles([{ storageKey: "photos/pic.webp" }])
 
       expect(added).toHaveLength(1)
       const file = added[0]!
@@ -851,10 +851,10 @@ describe("useUploadKit", () => {
       const storage = createMockStoragePlugin({ getRemoteFileFn })
       const uploader = useUploadKit({ storage })
 
-      await uploader.initializeExistingFiles([{ storageKey: "existing.png" }])
+      await uploader.setExistingFiles([{ storageKey: "existing.png" }])
       getRemoteFileFn.mockClear()
 
-      const added = await uploader.appendExistingFiles([{ storageKey: "existing.png" }, { storageKey: "new.png" }])
+      const added = await uploader.addExistingFiles([{ storageKey: "existing.png" }, { storageKey: "new.png" }])
 
       expect(added).toHaveLength(1)
       expect(added[0]!.storageKey).toBe("new.png")
@@ -880,7 +880,7 @@ describe("useUploadKit", () => {
       expect(uploader.files.value[0]!.storageKey).toBe("uploads/local.jpg")
 
       // Appending the same storageKey should be deduplicated
-      const added = await uploader.appendExistingFiles([{ storageKey: "uploads/local.jpg" }])
+      const added = await uploader.addExistingFiles([{ storageKey: "uploads/local.jpg" }])
 
       expect(added).toHaveLength(0)
       expect(uploader.files.value).toHaveLength(1)
@@ -894,7 +894,7 @@ describe("useUploadKit", () => {
       await uploader.addFile(createMockFile("file2.jpg"))
 
       // Only 1 slot available — should take the first from the input
-      const added = await uploader.appendExistingFiles([
+      const added = await uploader.addExistingFiles([
         { storageKey: "remote-1.jpg" },
         { storageKey: "remote-2.jpg" },
         { storageKey: "remote-3.jpg" },
@@ -913,7 +913,7 @@ describe("useUploadKit", () => {
       await uploader.addFile(createMockFile("file1.jpg"))
       getRemoteFileFn.mockClear()
 
-      const added = await uploader.appendExistingFiles([{ storageKey: "remote-1.jpg" }])
+      const added = await uploader.addExistingFiles([{ storageKey: "remote-1.jpg" }])
 
       expect(added).toHaveLength(0)
       // Should not make any network calls when limit is reached
@@ -926,7 +926,7 @@ describe("useUploadKit", () => {
       const handler = vi.fn()
 
       uploader.on("file:added", handler)
-      await uploader.appendExistingFiles([{ storageKey: "remote-1.jpg" }, { storageKey: "remote-2.jpg" }])
+      await uploader.addExistingFiles([{ storageKey: "remote-1.jpg" }, { storageKey: "remote-2.jpg" }])
 
       expect(handler).toHaveBeenCalledTimes(2)
       expect(handler).toHaveBeenCalledWith(expect.objectContaining({ storageKey: "remote-1.jpg" }))
@@ -937,11 +937,11 @@ describe("useUploadKit", () => {
       const storage = createMockStoragePlugin({ getRemoteFileFn: defaultGetRemoteFileFn })
       const uploader = useUploadKit({ storage })
 
-      await uploader.initializeExistingFiles([{ storageKey: "file-a.jpg" }])
+      await uploader.setExistingFiles([{ storageKey: "file-a.jpg" }])
 
       const handler = vi.fn()
       uploader.on("file:added", handler)
-      const added = await uploader.appendExistingFiles([{ storageKey: "file-a.jpg" }])
+      const added = await uploader.addExistingFiles([{ storageKey: "file-a.jpg" }])
 
       expect(added).toHaveLength(0)
       expect(handler).not.toHaveBeenCalled()
@@ -951,9 +951,9 @@ describe("useUploadKit", () => {
       const storage = createMockStoragePlugin({ getRemoteFileFn: defaultGetRemoteFileFn })
       const uploader = useUploadKit({ storage })
 
-      await uploader.appendExistingFiles([{ storageKey: "batch-1.jpg" }])
-      await uploader.appendExistingFiles([{ storageKey: "batch-2.jpg" }])
-      await uploader.appendExistingFiles([{ storageKey: "batch-1.jpg" }, { storageKey: "batch-3.jpg" }])
+      await uploader.addExistingFiles([{ storageKey: "batch-1.jpg" }])
+      await uploader.addExistingFiles([{ storageKey: "batch-2.jpg" }])
+      await uploader.addExistingFiles([{ storageKey: "batch-1.jpg" }, { storageKey: "batch-3.jpg" }])
 
       expect(uploader.files.value).toHaveLength(3)
       expect(uploader.files.value.map((f) => f.storageKey)).toEqual(["batch-1.jpg", "batch-2.jpg", "batch-3.jpg"])
@@ -962,7 +962,7 @@ describe("useUploadKit", () => {
     it("should throw if no storage plugin with getRemoteFile is configured", async () => {
       const uploader = useUploadKit()
 
-      await expect(uploader.appendExistingFiles([{ storageKey: "remote.jpg" }])).rejects.toThrow(
+      await expect(uploader.addExistingFiles([{ storageKey: "remote.jpg" }])).rejects.toThrow(
         "Storage plugin with getRemoteFile hook is required",
       )
     })
@@ -972,7 +972,7 @@ describe("useUploadKit", () => {
       const storage = createMockStoragePlugin({ getRemoteFileFn })
       const uploader = useUploadKit({ storage })
 
-      const added = await uploader.appendExistingFiles([{ storageKey: "" }, { storageKey: "valid.jpg" }])
+      const added = await uploader.addExistingFiles([{ storageKey: "" }, { storageKey: "valid.jpg" }])
 
       expect(added).toHaveLength(1)
       expect(added[0]!.storageKey).toBe("valid.jpg")
@@ -984,7 +984,7 @@ describe("useUploadKit", () => {
       const storage = createMockStoragePlugin({ getRemoteFileFn: defaultGetRemoteFileFn, removeFn: removeHook })
       const uploader = useUploadKit({ storage })
 
-      const added = await uploader.appendExistingFiles([{ storageKey: "library/photo.jpg" }])
+      const added = await uploader.addExistingFiles([{ storageKey: "library/photo.jpg" }])
       expect(uploader.files.value).toHaveLength(1)
 
       await uploader.removeFile(added[0]!.id)


### PR DESCRIPTION
## Summary

Closes #154. The old names did not signal the behavioral difference between the two methods — one replaces the file list while the other appends with dedup, maxFiles enforcement, and `file:added` emission.

Renames to `setExistingFiles` (replace) and `addExistingFiles` (append + dedup + maxFiles + emit), matching the `addFile`/`addFiles` naming already used elsewhere. Pre-1.0, hard rename with no deprecation shim. Tests and docs updated; CHANGELOG entries left as historical record.

## Test plan

- [x] `pnpm test` — 380/380 pass
- [x] `pnpm lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guides and adapter examples to use the new method names and to show preloaded file entries keyed by storageKey.
  * Clarified that deleteFromStorage: "local-only" preserves files loaded via setExistingFiles.

* **Refactor**
  * Renamed public APIs: initializeExistingFiles() → setExistingFiles(), and appendExistingFiles() → addExistingFiles().
<!-- end of auto-generated comment: release notes by coderabbit.ai -->