### PR TITLE
test(addFile): malformed filename coverage for ingestion

### DIFF
--- a/test/unit/useUploadKit.test.ts
+++ b/test/unit/useUploadKit.test.ts
@@ -112,6 +112,62 @@ describe("useUploadKit", () => {
       expect(handler).toHaveBeenCalledTimes(1)
       expect(handler).toHaveBeenCalledWith(expect.objectContaining({ name: "test.jpg" }))
     })
+
+    // ── Malformed filename coverage (#157) ──
+    // Pin current behaviour for weird filenames: everything `getExtension()` rejects
+    // throws "Invalid file name"; everything else is accepted with the name preserved.
+    // Not adding new validation -- purely regression protection so changes to
+    // ingestion cannot silently flip the behaviour on these inputs.
+    it("should throw for filename that is only an extension (.jpg)", async () => {
+      const uploader = useUploadKit()
+      const file = createMockFile(".jpg", 1024, "image/jpeg")
+
+      // getExtension treats ".jpg" as valid (lastDot=0, length=4, 0 != length-1).
+      // This call currently succeeds; pin that behaviour.
+      await uploader.addFile(file)
+      expect(uploader.files.value).toHaveLength(1)
+      expect(uploader.files.value[0]!.name).toBe(".jpg")
+    })
+
+    it("should throw when filename ends in a dot ('file.')", async () => {
+      const uploader = useUploadKit()
+      const file = createMockFile("file.", 1024, "image/jpeg")
+
+      // getExtension rejects when lastDot is at the end of the string.
+      await expect(uploader.addFile(file)).rejects.toThrow("Invalid file name")
+    })
+
+    it("should accept filename with null bytes and preserve it", async () => {
+      const uploader = useUploadKit()
+      const file = createMockFile("foo\0.jpg", 1024, "image/jpeg")
+
+      // Null-byte names are tolerated today -- storage keys use file.id, not the
+      // filename, so path-traversal is already not a concern here.
+      await uploader.addFile(file)
+      expect(uploader.files.value).toHaveLength(1)
+      expect(uploader.files.value[0]!.name).toBe("foo\0.jpg")
+    })
+
+    it("should accept unicode / emoji filenames and preserve them", async () => {
+      const uploader = useUploadKit()
+      const file = createMockFile("📎file.png", 1024, "image/png")
+
+      await uploader.addFile(file)
+      expect(uploader.files.value).toHaveLength(1)
+      expect(uploader.files.value[0]!.name).toBe("📎file.png")
+      expect(uploader.files.value[0]!.id).toMatch(/\.png$/)
+    })
+
+    it("should accept very long filenames (500+ chars) and preserve them", async () => {
+      const uploader = useUploadKit()
+      const longName = "a".repeat(500) + ".png"
+      const file = createMockFile(longName, 1024, "image/png")
+
+      await uploader.addFile(file)
+      expect(uploader.files.value).toHaveLength(1)
+      expect(uploader.files.value[0]!.name).toBe(longName)
+      expect(uploader.files.value[0]!.id).toMatch(/\.png$/)
+    })
   })
 
   describe("addFiles", () => {


### PR DESCRIPTION
## Summary

Closes #157. Pins current `addFile()` behaviour for weird filenames so a future edit to `getExtension()` or the ingestion path can't silently flip what happens on these inputs -- purely regression protection, no new validation.

## Why this matters

`src/runtime/composables/useUploadKit/utils.ts:getExtension()` throws on a couple of malformed shapes ("no extension", "ends in a dot") but everything else flows through to `addFile`, metadata, and presigned-URL generation without further filename checks (`plugins/storage/s3.ts:181`). Storage keys themselves come from the generated `file.id`, not the filename, so path traversal isn't a concern -- but odd inputs can still surface downstream bugs. Pinning the current behaviour means a future tightening of validation or a quiet loosening of `getExtension` can't happen accidentally.

## Changes

Five new cases in the existing `describe("addFile")` block of `test/unit/useUploadKit.test.ts`, each paired to one of the `## Proposed tests` bullets in the issue:

| Input                       | Current behaviour (pinned)                                 |
|-----------------------------|------------------------------------------------------------|
| `".jpg"` (only extension)   | accepted; name preserved (`getExtension` treats lastDot=0 as valid) |
| `"file."` (trailing dot)    | throws `"Invalid file name"` from `getExtension`           |
| `"foo .jpg"` (null byte)   | accepted; name preserved verbatim                          |
| `"📎file.png"` (emoji)       | accepted; name preserved; id still ends in `.png`          |
| `"a".repeat(500) + ".png"`  | accepted; name preserved; id still ends in `.png`          |

The existing `"should throw error for files without extension"` case on line ~95 already covers the bare `"noextension"` shape, so that's not duplicated here.

## Out of scope

- MIME spoofing / magic-number sniffing -- the issue calls this out as an intentional trust of `file.type`.
- New sanitization of filenames -- only documenting, not changing.

## Testing

```
$ pnpm test
 Test Files  13 passed (13)
      Tests  385 passed (385)
```

All pre-existing 380 tests still pass, plus the 5 new regression pins.

Closes #157

---

This contribution was developed with AI assistance (Claude Code).
