### PR TITLE
feat(useUploadKit): return `ready` promise alongside `isReady` ref (closes #156)

### DIFF
--- a/docs/content/1.get-started/2.configuration.md
+++ b/docs/content/1.get-started/2.configuration.md
@@ -121,6 +121,15 @@ Use `isReady` to show loading states while initial files are being fetched:
 </template>
 ```
 
+For imperative code, `await` the `ready` promise instead of watching the ref. It resolves once initial files have finished loading — on both success and error paths — and resolves immediately when no `initialFiles` is provided.
+
+```ts
+const uploader = useUploadKit({ initialFiles: ["uploads/photo1.jpg"] })
+
+await uploader.ready
+// uploader.files is now populated
+```
+
 ### Events
 
 Listen for initialization results:

--- a/docs/content/1.get-started/2.configuration.md
+++ b/docs/content/1.get-started/2.configuration.md
@@ -124,10 +124,14 @@ Use `isReady` to show loading states while initial files are being fetched:
 For imperative code, `await` the `ready` promise instead of watching the ref. It resolves once initial files have finished loading — on both success and error paths — and resolves immediately when no `initialFiles` is provided.
 
 ```ts
-const uploader = useUploadKit({ initialFiles: ["uploads/photo1.jpg"] })
+const uploader = useUploadKit({
+  storage: myStoragePlugin,
+  initialFiles: ["uploads/photo1.jpg"],
+})
 
 await uploader.ready
-// uploader.files is now populated
+// uploader.files is populated once remote resolution succeeds;
+// on failure, listen for the `initialFiles:error` event.
 ```
 
 ### Events

--- a/docs/content/2.usage/1.overview.md
+++ b/docs/content/2.usage/1.overview.md
@@ -50,6 +50,7 @@ The composable returns an object with the following properties and methods:
 | `totalProgress` | `ComputedRef<number>`         | Overall upload progress (0-100)                      |
 | `status`        | `Ref<UploadStatus>`           | Current upload status (`'waiting'` or `'uploading'`) |
 | `isReady`       | `Readonly<Ref<boolean>>`      | `true` when initialization is complete               |
+| `ready`         | `Promise<void>`               | Resolves once `initialFiles` have finished loading   |
 
 ### Core Methods
 

--- a/src/runtime/composables/useUploadKit/index.ts
+++ b/src/runtime/composables/useUploadKit/index.ts
@@ -39,6 +39,12 @@ export const useUploadKit = <TUploadResult = unknown>(
   const status = ref<UploadStatus>("waiting")
   const isReady = ref(options.initialFiles === undefined)
 
+  let resolveReady!: () => void
+  const ready = new Promise<void>((resolve) => {
+    resolveReady = resolve
+  })
+  if (options.initialFiles === undefined) resolveReady()
+
   // Track created object URLs for automatic cleanup
   const createdObjectURLs = new Map<string, string>()
 
@@ -362,6 +368,7 @@ export const useUploadKit = <TUploadResult = unknown>(
     isReady,
     emitter,
     setExistingFiles,
+    onReady: resolveReady,
   })
 
   return {
@@ -369,6 +376,7 @@ export const useUploadKit = <TUploadResult = unknown>(
     files: readonly(files),
     totalProgress,
     isReady: readonly(isReady),
+    ready,
 
     // Core Methods
     addFiles,

--- a/src/runtime/composables/useUploadKit/utils.ts
+++ b/src/runtime/composables/useUploadKit/utils.ts
@@ -143,16 +143,23 @@ export function setupInitialFiles<TUploadResult>({
   isReady,
   emitter,
   setExistingFiles,
+  onReady,
 }: {
   initialFiles: UploadOptions["initialFiles"]
   files: { value: UploadFile<TUploadResult>[] }
   isReady: { value: boolean }
   emitter: { emit: (type: string, data: unknown) => void }
   setExistingFiles: (files: InitialFileInput[]) => Promise<void>
+  onReady: () => void
 }) {
   if (initialFiles === undefined) return
 
   let isInitialized = false
+
+  const markReady = () => {
+    isReady.value = true
+    onReady()
+  }
 
   const doInitialize = async (value: string | string[] | undefined) => {
     if (isInitialized || !value || files.value.length > 0) return
@@ -162,14 +169,14 @@ export function setupInitialFiles<TUploadResult>({
       isInitialized = true
       try {
         await setExistingFiles(paths.map((storageKey) => ({ storageKey })))
-        isReady.value = true
         emitter.emit("initialFiles:loaded", files.value)
       } catch (error) {
-        isReady.value = true
         emitter.emit("initialFiles:error", error)
+      } finally {
+        markReady()
       }
     } else {
-      isReady.value = true
+      markReady()
     }
   }
 

--- a/test/unit/useUploadKit.test.ts
+++ b/test/unit/useUploadKit.test.ts
@@ -1375,6 +1375,56 @@ describe("useUploadKit", () => {
       expect(uploader.files.value).toHaveLength(0)
     })
 
+    it("should resolve `ready` immediately when no initialFiles provided", async () => {
+      const uploader = useUploadKit()
+      await expect(uploader.ready).resolves.toBeUndefined()
+    })
+
+    it("should resolve `ready` after initialFiles load successfully", async () => {
+      const uploader = useUploadKit({
+        initialFiles: ["file1.jpg"],
+        storage: createMockStoragePlugin(),
+      })
+
+      await uploader.ready
+
+      expect(uploader.isReady.value).toBe(true)
+      expect(uploader.files.value).toHaveLength(1)
+    })
+
+    it("should resolve `ready` even when initialFiles loading fails", async () => {
+      const uploader = useUploadKit({
+        initialFiles: ["file1.jpg"],
+        storage: createMockStoragePlugin({
+          getRemoteFileFn: async () => {
+            throw new Error("Storage unavailable")
+          },
+        }),
+      })
+
+      await expect(uploader.ready).resolves.toBeUndefined()
+      expect(uploader.isReady.value).toBe(true)
+    })
+
+    it("should resolve `ready` for empty initialFiles array", async () => {
+      const uploader = useUploadKit({ initialFiles: [] })
+      await expect(uploader.ready).resolves.toBeUndefined()
+    })
+
+    it("should resolve `ready` after deferred ref populates", async () => {
+      const filesRef = ref<string[] | undefined>(undefined)
+      const uploader = useUploadKit({
+        initialFiles: filesRef,
+        storage: createMockStoragePlugin(),
+      })
+
+      filesRef.value = ["deferred.jpg"]
+      await uploader.ready
+
+      expect(uploader.isReady.value).toBe(true)
+      expect(uploader.files.value).toHaveLength(1)
+    })
+
     it("should set uploadResult on initialized files from storage plugin", async () => {
       // This test ensures that files initialized via initialFiles have uploadResult set,
       // making them consistent with newly uploaded files. This is important for consumers

--- a/test/unit/validators/duplicate-file.test.ts
+++ b/test/unit/validators/duplicate-file.test.ts
@@ -271,8 +271,17 @@ describe("ValidatorDuplicateFile", () => {
 
     it("should handle empty filename", async () => {
       const validator = ValidatorDuplicateFile({})
-      const existingFile = createMockLocalUploadFile({ name: "", size: 1024 })
-      const newFile = createMockLocalUploadFile({ name: "", size: 1024 })
+      const lastModified = Date.now()
+      const existingFile = createMockLocalUploadFile({
+        name: "",
+        size: 1024,
+        data: createMockFile("test-file.jpg", 1024, "image/jpeg", lastModified),
+      })
+      const newFile = createMockLocalUploadFile({
+        name: "",
+        size: 1024,
+        data: createMockFile("test-file.jpg", 1024, "image/jpeg", lastModified),
+      })
       const context = createMockPluginContext([existingFile])
 
       await expect(validator.hooks.validate!(newFile, context)).rejects.toEqual({


### PR DESCRIPTION
## Summary

Adds a `ready: Promise<void>` to the `useUploadKit` return value that resolves once `initialFiles` have finished loading — on both success and error paths, and immediately when no `initialFiles` is provided. Lets consumers `await uploader.ready` instead of watching the `isReady` ref.

## Changes

- `setupInitialFiles` takes an `onReady` callback, called via `finally` so the error path resolves too
- `ready` promise constructed in `useUploadKit` and returned alongside the existing `isReady` ref (non-breaking)
- 5 new tests; docs updated in `configuration.md` and `usage/overview.md`

## Test plan

- [x] `pnpm test` — 385 passed
- [x] `pnpm lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a `ready` promise on the upload API that resolves after initial files finish loading; resolves immediately when no initial files are provided.

* **Documentation**
  * Added docs and TypeScript examples demonstrating awaiting `ready` and handling success, error, empty, and deferred initial-files cases.

* **Tests**
  * Added unit tests covering `ready` behavior (success, failure, empty, deferred) and improved duplicate-file test to use file-based detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->