### PR TITLE
test: cover malformed filenames in ingestion (closes #157)

### DIFF
--- a/test/unit/useUploadKit.test.ts
+++ b/test/unit/useUploadKit.test.ts
@@ -101,6 +101,51 @@ describe("useUploadKit", () => {
       await expect(uploader.addFile(file)).rejects.toThrow("Invalid file name")
     })
 
+    it("should accept filenames containing a null byte and preserve the name", async () => {
+      const uploader = useUploadKit()
+      const file = createMockFile("foo\0.jpg", 1024, "image/jpeg")
+
+      await uploader.addFile(file)
+
+      expect(uploader.files.value).toHaveLength(1)
+      expect(uploader.files.value[0]!.name).toBe("foo\0.jpg")
+      expect(uploader.files.value[0]!.id).toMatch(/\.jpg$/)
+    })
+
+    it("should accept unicode / emoji filenames and preserve the name", async () => {
+      const uploader = useUploadKit()
+      const file = createMockFile("📎file.png", 1024, "image/png")
+
+      await uploader.addFile(file)
+
+      expect(uploader.files.value).toHaveLength(1)
+      expect(uploader.files.value[0]!.name).toBe("📎file.png")
+      expect(uploader.files.value[0]!.id).toMatch(/\.png$/)
+    })
+
+    it("should accept very long filenames and preserve the name", async () => {
+      const uploader = useUploadKit()
+      const longName = `${"a".repeat(500)}.jpg`
+      const file = createMockFile(longName, 1024, "image/jpeg")
+
+      await uploader.addFile(file)
+
+      expect(uploader.files.value).toHaveLength(1)
+      expect(uploader.files.value[0]!.name).toBe(longName)
+      expect(uploader.files.value[0]!.id).toMatch(/\.jpg$/)
+    })
+
+    it("should accept dotfile-style names like '.jpg'", async () => {
+      const uploader = useUploadKit()
+      const file = createMockFile(".jpg", 1024, "image/jpeg")
+
+      await uploader.addFile(file)
+
+      expect(uploader.files.value).toHaveLength(1)
+      expect(uploader.files.value[0]!.name).toBe(".jpg")
+      expect(uploader.files.value[0]!.id).toMatch(/\.jpg$/)
+    })
+
     it("should emit file:added event when file is added", async () => {
       const uploader = useUploadKit()
       const file = createMockFile("test.jpg")

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -6,6 +6,7 @@ import {
   cleanupObjectURLs,
   dataUrlToBlob,
   deriveThumbnailKey,
+  getExtension,
 } from "../../src/runtime/composables/useUploadKit/utils"
 import { createMockLocalUploadFile } from "../helpers"
 import mitt from "mitt"
@@ -403,6 +404,48 @@ describe("utils", () => {
 
     it("should handle WebP extension", () => {
       expect(deriveThumbnailKey("image.webp")).toBe("image_thumb.webp")
+    })
+  })
+
+  describe("getExtension", () => {
+    it("should return the extension for a simple filename", () => {
+      expect(getExtension("photo.jpg")).toBe("jpg")
+    })
+
+    it("should lowercase the extension", () => {
+      expect(getExtension("photo.JPG")).toBe("jpg")
+    })
+
+    it("should use the last dot when there are multiple", () => {
+      expect(getExtension("archive.tar.gz")).toBe("gz")
+    })
+
+    it("should throw for filenames with no extension", () => {
+      expect(() => getExtension("noextension")).toThrow("Invalid file name")
+    })
+
+    it("should throw for filenames ending in a dot", () => {
+      expect(() => getExtension("trailing.")).toThrow("Invalid file name")
+    })
+
+    it("should throw for an empty string", () => {
+      expect(() => getExtension("")).toThrow("Invalid file name")
+    })
+
+    it("should accept dotfile-style names like '.jpg' and return the extension", () => {
+      expect(getExtension(".jpg")).toBe("jpg")
+    })
+
+    it("should accept names containing a null byte", () => {
+      expect(getExtension("foo\0.jpg")).toBe("jpg")
+    })
+
+    it("should accept unicode and emoji in the filename", () => {
+      expect(getExtension("📎file.png")).toBe("png")
+    })
+
+    it("should accept very long filenames", () => {
+      expect(getExtension(`${"a".repeat(500)}.jpg`)).toBe("jpg")
     })
   })
 })


### PR DESCRIPTION
Pins current behavior of `getExtension()` and `addFile()` for odd filename inputs: no-extension/trailing-dot/empty throw, while null bytes, unicode/emoji, 500+ char names, and dotfile-style `.jpg` are accepted with the name preserved verbatim. Regression coverage only — no behavior change.