### PR TITLE
fix(useUploadKit): prevent duplicate storage uploads on concurrent upload() calls

### DIFF
--- a/src/runtime/composables/useUploadKit/index.ts
+++ b/src/runtime/composables/useUploadKit/index.ts
@@ -174,7 +174,15 @@ export const useUploadKit = <TUploadResult = unknown>(
   }
 
   const upload = async () => {
-    const filesToUpload = files.value.filter((f) => f.status === "waiting")
+    // Synchronously flip status off "waiting" so a concurrent upload() call
+    // issued in the same tick won't re-select these files (see #169).
+    const idsToUpload = files.value.filter((f) => f.status === "waiting").map((f) => f.id)
+    for (const id of idsToUpload) {
+      updateFile(id, { status: "uploading" })
+    }
+    const filesToUpload = idsToUpload
+      .map((id) => files.value.find((f) => f.id === id))
+      .filter((f): f is UploadFile<TUploadResult> => f !== undefined)
 
     emitter.emit("upload:start", filesToUpload)
 

--- a/test/unit/useUploadKit.test.ts
+++ b/test/unit/useUploadKit.test.ts
@@ -701,7 +701,7 @@ describe("useUploadKit", () => {
         expect(completeHandler).toHaveBeenCalledTimes(2)
       })
 
-      it("should currently invoke storage upload twice when upload() is called back-to-back without awaiting (pinned; see #169)", async () => {
+      it("should upload each file exactly once even when upload() is called back-to-back without awaiting (#169)", async () => {
         const uploadHook = vi.fn().mockResolvedValue({ url: "https://example.com/file.jpg", storageKey: "k" })
         const storage: StoragePlugin = {
           id: "test-storage",
@@ -718,10 +718,7 @@ describe("useUploadKit", () => {
         const p2 = uploader.upload()
         await Promise.all([p1, p2])
 
-        // Pins current behavior: concurrent unawaited calls result in the storage hook being
-        // invoked twice for the same file. If this test fails in the future because the count
-        // drops to 1, that's a bugfix — update the assertion.
-        expect(uploadHook).toHaveBeenCalledTimes(2)
+        expect(uploadHook).toHaveBeenCalledTimes(1)
       })
     })
 


### PR DESCRIPTION
Closes #169.

Concurrent `upload()` calls in the same tick both saw the same `waiting` files because status didn't flip to `uploading` until after the first `await` inside `uploadSingleFile`, causing the storage plugin's `upload` hook to fire twice per file.

Fix: synchronously flip matched files to `uploading` in `upload()` before any await. Since `updateFile` replaces the object in `files.value`, the loop re-resolves current refs post-flip so downstream in-place mutations (e.g. the thumbnail plugin setting `file.thumbnail`) target the live object.

Flipped the pinning test assertion from `.toHaveBeenCalledTimes(2)` to `.toHaveBeenCalledTimes(1)` per the issue's acceptance criteria. All 403 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a concurrency issue where rapid consecutive file upload calls could cause files to be uploaded multiple times. Files are now correctly processed during simultaneous upload operations.

* **Tests**
  * Updated upload concurrency tests to verify correct behavior with rapid successive calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->