### PR TITLE
feat(v0.2): scaffold module server half

### DIFF
--- a/playground/server/upload.server.config.ts
+++ b/playground/server/upload.server.config.ts
@@ -1,0 +1,7 @@
+import { defineUploadServerConfig } from "#upload-kit/server"
+
+export default defineUploadServerConfig({
+  authorize: async () => {
+    return { userId: "playground" }
+  },
+})

--- a/src/module.ts
+++ b/src/module.ts
@@ -69,17 +69,17 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.nitro.alias = nuxt.options.nitro.alias ?? {}
     nuxt.options.nitro.alias["#upload-kit/server"] = resolver.resolve("./runtime/server")
 
-    // Auto-import useServerUpload in Nitro
-    addServerImports([
-      {
-        name: "useServerUpload",
-        from: resolver.resolve("./runtime/server/use-server-upload"),
-      },
-    ])
+    if (options.autoImport) {
+      addServerImports([
+        {
+          name: "useServerUpload",
+          from: resolver.resolve("./runtime/server/use-server-upload"),
+        },
+      ])
+    }
 
     // Detect convention file
-    const srcDir = nuxt.options.rootDir
-    const conventionFile = join(srcDir, "server/upload.server.config.ts")
+    const conventionFile = join(nuxt.options.serverDir, "upload.server.config.ts")
     if (!existsSync(conventionFile)) {
       logger.warn(
         "No server config found at `server/upload.server.config.ts`. Server-side uploads are disabled. " +

--- a/src/module.ts
+++ b/src/module.ts
@@ -85,6 +85,7 @@ export default defineNuxtModule<ModuleOptions>({
         "No server config found at `server/upload.server.config.ts`. Server-side uploads are disabled. " +
           "Create the file and export `defineUploadServerConfig({ storage, ... })` to enable them.",
       )
+      return
     }
 
     // Catch-all stub handler

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,6 @@
-import { defineNuxtModule, addImports, createResolver } from "@nuxt/kit"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+import { defineNuxtModule, addImports, addServerHandler, addServerImports, createResolver, useLogger } from "@nuxt/kit"
 
 // Export all types from runtime
 export type * from "./runtime/types"
@@ -10,6 +12,13 @@ export interface ModuleOptions {
    * @default true
    */
   autoImport?: boolean
+
+  /**
+   * Mount path for the auto-generated server endpoints.
+   * The catch-all handler is registered at `${handlerRoute}/**`.
+   * @default "/api/_upload"
+   */
+  handlerRoute?: string
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -19,26 +28,27 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {
     autoImport: true,
+    handlerRoute: "/api/_upload",
   },
-  setup(options, _nuxt) {
+  setup(options, nuxt) {
     const resolver = createResolver(import.meta.url)
+    const logger = useLogger("nuxt-upload-kit")
 
     // Configure Vite's dependency optimization
-    _nuxt.options.vite = _nuxt.options.vite ?? {}
-    _nuxt.options.vite.optimizeDeps = _nuxt.options.vite.optimizeDeps ?? {}
+    nuxt.options.vite = nuxt.options.vite ?? {}
+    nuxt.options.vite.optimizeDeps = nuxt.options.vite.optimizeDeps ?? {}
 
     // Exclude FFmpeg packages - they use Web Workers that don't work correctly when pre-bundled
     // @see https://github.com/ffmpegwasm/ffmpeg.wasm/issues/532
-    _nuxt.options.vite.optimizeDeps.exclude = _nuxt.options.vite.optimizeDeps.exclude ?? []
-    _nuxt.options.vite.optimizeDeps.exclude.push("@ffmpeg/ffmpeg", "@ffmpeg/util")
+    nuxt.options.vite.optimizeDeps.exclude = nuxt.options.vite.optimizeDeps.exclude ?? []
+    nuxt.options.vite.optimizeDeps.exclude.push("@ffmpeg/ffmpeg", "@ffmpeg/util")
 
     // Include Node.js polyfills required by Azure SDK (used by Azure DataLake storage plugin)
     // The `events` package uses CommonJS exports that need pre-bundling for browser ESM
-    _nuxt.options.vite.optimizeDeps.include = _nuxt.options.vite.optimizeDeps.include ?? []
-    _nuxt.options.vite.optimizeDeps.include.push("events")
+    nuxt.options.vite.optimizeDeps.include = nuxt.options.vite.optimizeDeps.include ?? []
+    nuxt.options.vite.optimizeDeps.include.push("events")
 
     if (options.autoImport) {
-      // Auto-import useUploadKit composable
       addImports([
         {
           name: "useUploadKit",
@@ -51,7 +61,37 @@ export default defineNuxtModule<ModuleOptions>({
       ])
     }
 
-    // Add #upload-kit alias for types and runtime
-    _nuxt.options.alias["#upload-kit"] = resolver.resolve("./runtime")
+    // Client alias
+    nuxt.options.alias["#upload-kit"] = resolver.resolve("./runtime")
+
+    // Server alias — resolves in Nitro for `import { defineUploadServerConfig } from "#upload-kit/server"`
+    nuxt.options.nitro = nuxt.options.nitro ?? {}
+    nuxt.options.nitro.alias = nuxt.options.nitro.alias ?? {}
+    nuxt.options.nitro.alias["#upload-kit/server"] = resolver.resolve("./runtime/server")
+
+    // Auto-import useServerUpload in Nitro
+    addServerImports([
+      {
+        name: "useServerUpload",
+        from: resolver.resolve("./runtime/server/use-server-upload"),
+      },
+    ])
+
+    // Detect convention file
+    const srcDir = nuxt.options.rootDir
+    const conventionFile = join(srcDir, "server/upload.server.config.ts")
+    if (!existsSync(conventionFile)) {
+      logger.warn(
+        "No server config found at `server/upload.server.config.ts`. Server-side uploads are disabled. " +
+          "Create the file and export `defineUploadServerConfig({ storage, ... })` to enable them.",
+      )
+    }
+
+    // Catch-all stub handler
+    const handlerRoute = options.handlerRoute ?? "/api/_upload"
+    addServerHandler({
+      route: `${handlerRoute}/**`,
+      handler: resolver.resolve("./runtime/server/handler"),
+    })
   },
 })

--- a/src/runtime/server/define-config.ts
+++ b/src/runtime/server/define-config.ts
@@ -1,0 +1,5 @@
+import type { UploadServerConfig } from "./types"
+
+export function defineUploadServerConfig(config: UploadServerConfig): UploadServerConfig {
+  return config
+}

--- a/src/runtime/server/handler.ts
+++ b/src/runtime/server/handler.ts
@@ -1,0 +1,9 @@
+import { defineEventHandler, createError } from "h3"
+
+export default defineEventHandler(() => {
+  throw createError({
+    statusCode: 501,
+    statusMessage: "Not Implemented",
+    message: "nuxt-upload-kit server endpoints are not yet implemented (v0.2 scaffold).",
+  })
+})

--- a/src/runtime/server/index.ts
+++ b/src/runtime/server/index.ts
@@ -1,0 +1,2 @@
+export { defineUploadServerConfig } from "./define-config"
+export type * from "./types"

--- a/src/runtime/server/types.ts
+++ b/src/runtime/server/types.ts
@@ -1,0 +1,43 @@
+import type { H3Event } from "h3"
+
+export interface UploadFileDescriptor {
+  name: string
+  size: number
+  mimeType: string
+}
+
+export type AuthorizeOp =
+  | { type: "presign-upload"; file: UploadFileDescriptor }
+  | { type: "presign-download"; key: string }
+  | { type: "delete"; key: string }
+  | { type: "direct-upload"; file: UploadFileDescriptor }
+  | { type: "list"; prefix?: string }
+
+export interface AuthorizeContext {
+  userId?: string
+  [key: string]: unknown
+}
+
+export interface ServerHookContext {
+  event: H3Event
+  auth: AuthorizeContext
+}
+
+export interface UploadServerConfig {
+  storage?: unknown
+  authorize?: (event: H3Event, op: AuthorizeOp) => AuthorizeContext | Promise<AuthorizeContext>
+  validators?: unknown[]
+  hooks?: {
+    beforePresign?: (file: UploadFileDescriptor, ctx: ServerHookContext) => void | Promise<void>
+    afterUpload?: (file: UploadFileDescriptor, ctx: ServerHookContext) => void | Promise<void>
+    beforeDelete?: (key: string, ctx: ServerHookContext) => void | Promise<void>
+  }
+}
+
+export interface ServerUpload {
+  put: (input: { key: string; body: unknown; contentType?: string }) => Promise<unknown>
+  presignUpload: (input: UploadFileDescriptor) => Promise<unknown>
+  presignDownload: (key: string) => Promise<unknown>
+  delete: (key: string) => Promise<unknown>
+  list: (prefix?: string) => Promise<unknown>
+}

--- a/src/runtime/server/use-server-upload.ts
+++ b/src/runtime/server/use-server-upload.ts
@@ -1,7 +1,7 @@
 import type { H3Event } from "h3"
 import type { ServerUpload } from "./types"
 
-const NOT_CONFIGURED = (op: string) => () => {
+const NOT_CONFIGURED = (op: string) => async () => {
   throw new Error(
     `[nuxt-upload-kit] useServerUpload().${op}() called but server is not configured. ` +
       `Create ~~/server/upload.server.config.ts and export defineUploadServerConfig({ storage, ... }).`,

--- a/src/runtime/server/use-server-upload.ts
+++ b/src/runtime/server/use-server-upload.ts
@@ -1,0 +1,19 @@
+import type { H3Event } from "h3"
+import type { ServerUpload } from "./types"
+
+const NOT_CONFIGURED = (op: string) => () => {
+  throw new Error(
+    `[nuxt-upload-kit] useServerUpload().${op}() called but server is not configured. ` +
+      `Create ~~/server/upload.server.config.ts and export defineUploadServerConfig({ storage, ... }).`,
+  )
+}
+
+export function useServerUpload(_event: H3Event): ServerUpload {
+  return {
+    put: NOT_CONFIGURED("put"),
+    presignUpload: NOT_CONFIGURED("presignUpload"),
+    presignDownload: NOT_CONFIGURED("presignDownload"),
+    delete: NOT_CONFIGURED("delete"),
+    list: NOT_CONFIGURED("list"),
+  }
+}


### PR DESCRIPTION
Part of #179, closes #182. Lays down the server-side plumbing so later PRs can plug providers and endpoints into it — no user-visible upload behavior yet.

## Summary

- Add `defineUploadServerConfig` helper and server types (`src/runtime/server/`).
- Register `#upload-kit/server` alias for Nitro so the convention config can import it.
- Auto-import `useServerUpload(event)` in Nitro; returns a stub that throws "not configured" until a provider PR wires it up.
- Add catch-all server handler at `${handlerRoute}/**` (default `/api/_upload`) returning 501 Not Implemented.
- Detect `~~/server/upload.server.config.ts` at setup; log a warning and skip server wiring if missing.
- New module option `handlerRoute` to customize the mount path.
- Playground gains `server/upload.server.config.ts` for smoke testing.

## Test plan

- [x] `pnpm dev:prepare` — clean, types generated
- [x] `pnpm dev` boots with playground server config; `curl /api/_upload/presign` → 501
- [x] `vue-tsc -p .nuxt/tsconfig.server.json` — `useServerUpload(event)` type-checks
- [x] `pnpm lint` + `pnpm test` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side upload framework: authorization, storage configuration, validators, lifecycle hooks, and a server-side upload API (put/presign/download/delete/list).
* **Behavior**
  * Server endpoints currently respond as “not implemented” and client helpers emit a clear message instructing to provide a server upload configuration.
* **Chores**
  * Added a playground default server upload configuration with a placeholder authorization response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->