### PR TITLE
ci(release): tie Vercel prod docs to npm release via 'release' branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,3 +57,6 @@ jobs:
 
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
+
+      - name: Promote docs to release branch
+        run: git push origin HEAD:release --force

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,10 @@ The `/docs` folder uses Docus (built on Nuxt Content):
 - Config: `docs/app.config.ts` (header, socials, theme)
 - MDC components: `::component-name` syntax for Vue components in markdown
 
+### Docs deployment
+
+Vercel's production branch is `release`, not `master`. The Release workflow fast-forwards `release` to the published commit after a successful `npm publish`, so prod docs always match the latest published npm version. Master pushes only get Vercel preview deploys per-PR.
+
 ## Code Review Guidelines
 
 When reviewing storage adapters or SDK integrations, do NOT recommend:


### PR DESCRIPTION
## Summary

Vercel's production docs deploy currently fires on every push to master, which means prod docs can document APIs not yet published to npm. This wires prod docs to the published version instead.

- The release workflow's `publish` job now force-pushes `HEAD` to a `release` branch after a successful `npm publish`.
- Vercel's production branch should be changed from `master` to `release` (manual dashboard setting, not in this diff). After that, master pushes only produce Vercel preview deploys, and prod docs move only when npm moves.
- `CLAUDE.md` documents the new arrangement.

## Test plan

- [ ] Confirm Vercel production branch is set to `release` before merging
- [ ] After merge, verify the next release-please publish run pushes to `release` and triggers a Vercel prod deploy
- [ ] Confirm a subsequent non-release master push only produces a preview deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance clarifying the production deployment branch configuration and the relationship between publishing, release automation, and deployment triggers.

* **Chores**
  * Enhanced release workflow automation for branch management following package publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->