### PR TITLE
feat(v0.2): download and delete endpoints (#185)

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -105,5 +105,17 @@ export default defineNuxtModule<ModuleOptions>({
       method: "post",
       handler: resolver.resolve("./runtime/server/handlers/presign"),
     })
+
+    addServerHandler({
+      route: `${handlerRoute}/download/:fileId`,
+      method: "get",
+      handler: resolver.resolve("./runtime/server/handlers/download"),
+    })
+
+    addServerHandler({
+      route: `${handlerRoute}/:fileId`,
+      method: "delete",
+      handler: resolver.resolve("./runtime/server/handlers/delete"),
+    })
   },
 })

--- a/src/runtime/server/handlers/delete.ts
+++ b/src/runtime/server/handlers/delete.ts
@@ -1,0 +1,37 @@
+import { defineEventHandler, getRouterParam, createError } from "h3"
+// @ts-expect-error virtual user-config import
+import userConfig from "#upload-kit-user-config"
+import type { UploadServerConfig, ServerHookContext } from "../types"
+
+const config = userConfig as UploadServerConfig
+
+export default defineEventHandler(async (event) => {
+  if (!config.storage) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Server Misconfigured",
+      message: "No storage adapter configured. Set `storage` in your upload.server.config.ts.",
+    })
+  }
+  if (!config.storage.delete) {
+    throw createError({
+      statusCode: 501,
+      statusMessage: "Not Implemented",
+      message: `Storage adapter "${config.storage.id}" does not implement delete().`,
+    })
+  }
+
+  const raw = getRouterParam(event, "fileId")
+  if (!raw) {
+    throw createError({ statusCode: 400, statusMessage: "Bad Request", message: "Missing fileId." })
+  }
+  const key = decodeURIComponent(raw)
+
+  const auth = config.authorize ? await config.authorize(event, { type: "delete", key }) : {}
+  const ctx: ServerHookContext = { event, auth }
+
+  await config.hooks?.beforeDelete?.(key, ctx)
+  await config.storage.delete(key, ctx)
+
+  return { ok: true }
+})

--- a/src/runtime/server/handlers/delete.ts
+++ b/src/runtime/server/handlers/delete.ts
@@ -25,7 +25,12 @@ export default defineEventHandler(async (event) => {
   if (!raw) {
     throw createError({ statusCode: 400, statusMessage: "Bad Request", message: "Missing fileId." })
   }
-  const key = decodeURIComponent(raw)
+  let key: string
+  try {
+    key = decodeURIComponent(raw)
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: "Bad Request", message: "Invalid fileId encoding." })
+  }
 
   const auth = config.authorize ? await config.authorize(event, { type: "delete", key }) : {}
   const ctx: ServerHookContext = { event, auth }

--- a/src/runtime/server/handlers/download.ts
+++ b/src/runtime/server/handlers/download.ts
@@ -1,0 +1,35 @@
+import { defineEventHandler, getRouterParam, createError } from "h3"
+// @ts-expect-error virtual user-config import
+import userConfig from "#upload-kit-user-config"
+import type { UploadServerConfig, ServerHookContext } from "../types"
+
+const config = userConfig as UploadServerConfig
+
+export default defineEventHandler(async (event) => {
+  if (!config.storage) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Server Misconfigured",
+      message: "No storage adapter configured. Set `storage` in your upload.server.config.ts.",
+    })
+  }
+  if (!config.storage.presignDownload) {
+    throw createError({
+      statusCode: 501,
+      statusMessage: "Not Implemented",
+      message: `Storage adapter "${config.storage.id}" does not implement presignDownload().`,
+    })
+  }
+
+  const raw = getRouterParam(event, "fileId")
+  if (!raw) {
+    throw createError({ statusCode: 400, statusMessage: "Bad Request", message: "Missing fileId." })
+  }
+  // Clients URL-encode keys that contain "/"; decode back to the raw storage key.
+  const key = decodeURIComponent(raw)
+
+  const auth = config.authorize ? await config.authorize(event, { type: "presign-download", key }) : {}
+  const ctx: ServerHookContext = { event, auth }
+
+  return await config.storage.presignDownload(key, ctx)
+})

--- a/src/runtime/server/handlers/download.ts
+++ b/src/runtime/server/handlers/download.ts
@@ -26,7 +26,12 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Bad Request", message: "Missing fileId." })
   }
   // Clients URL-encode keys that contain "/"; decode back to the raw storage key.
-  const key = decodeURIComponent(raw)
+  let key: string
+  try {
+    key = decodeURIComponent(raw)
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: "Bad Request", message: "Invalid fileId encoding." })
+  }
 
   const auth = config.authorize ? await config.authorize(event, { type: "presign-download", key }) : {}
   const ctx: ServerHookContext = { event, auth }

--- a/test/unit/server/delete-handler.test.ts
+++ b/test/unit/server/delete-handler.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { createError } from "h3"
+import type { StorageAdapter, UploadServerConfig } from "../../../src/runtime/server/types"
+
+let userConfig: UploadServerConfig
+
+vi.mock("#upload-kit-user-config", () => ({
+  get default() {
+    return userConfig
+  },
+}))
+
+const stubStorage = (): StorageAdapter & { delete: ReturnType<typeof vi.fn> } => ({
+  id: "stub",
+  presignUpload: vi.fn(),
+  delete: vi.fn(async () => {}),
+})
+
+const callHandler = async () => {
+  const mod = await import("../../../src/runtime/server/handlers/delete")
+  return mod.default
+}
+
+const fakeEvent = (fileId: string) =>
+  ({
+    node: { req: { method: "DELETE", headers: {} } },
+    context: { params: { fileId } },
+  }) as unknown as Parameters<Awaited<ReturnType<typeof callHandler>>>[0]
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+describe("delete handler", () => {
+  it("authorizes, runs beforeDelete, then deletes", async () => {
+    const order: string[] = []
+    const storage = stubStorage()
+    storage.delete.mockImplementation(async () => {
+      order.push("delete")
+    })
+    userConfig = {
+      storage,
+      authorize: async () => {
+        order.push("authorize")
+        return { userId: "u1" }
+      },
+      hooks: {
+        beforeDelete: async () => {
+          order.push("beforeDelete")
+        },
+      },
+    }
+
+    const handler = await callHandler()
+    const result = await handler(fakeEvent("uploads%2Fabc.png"))
+
+    expect(order).toEqual(["authorize", "beforeDelete", "delete"])
+    expect(storage.delete).toHaveBeenCalledWith("uploads/abc.png", expect.objectContaining({ auth: { userId: "u1" } }))
+    expect(result).toEqual({ ok: true })
+  })
+
+  it("propagates authorize errors before deleting", async () => {
+    const storage = stubStorage()
+    userConfig = {
+      storage,
+      authorize: async () => {
+        throw createError({ statusCode: 403, message: "nope" })
+      },
+    }
+
+    const handler = await callHandler()
+    await expect(handler(fakeEvent("abc"))).rejects.toMatchObject({ statusCode: 403 })
+    expect(storage.delete).not.toHaveBeenCalled()
+  })
+
+  it("propagates beforeDelete errors before deleting", async () => {
+    const storage = stubStorage()
+    userConfig = {
+      storage,
+      hooks: {
+        beforeDelete: async () => {
+          throw createError({ statusCode: 409, message: "in use" })
+        },
+      },
+    }
+
+    const handler = await callHandler()
+    await expect(handler(fakeEvent("abc"))).rejects.toMatchObject({ statusCode: 409 })
+    expect(storage.delete).not.toHaveBeenCalled()
+  })
+
+  it("returns 400 when fileId is missing", async () => {
+    userConfig = { storage: stubStorage() }
+    const handler = await callHandler()
+    await expect(
+      handler({ node: { req: { method: "DELETE", headers: {} } }, context: { params: {} } } as never),
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it("returns 501 when the adapter doesn't implement delete", async () => {
+    userConfig = { storage: { id: "stub", presignUpload: vi.fn() } }
+    const handler = await callHandler()
+    await expect(handler(fakeEvent("abc"))).rejects.toMatchObject({ statusCode: 501 })
+  })
+
+  it("returns 500 when storage is not configured", async () => {
+    userConfig = {}
+    const handler = await callHandler()
+    await expect(handler(fakeEvent("abc"))).rejects.toMatchObject({ statusCode: 500 })
+  })
+})

--- a/test/unit/server/delete-handler.test.ts
+++ b/test/unit/server/delete-handler.test.ts
@@ -89,6 +89,14 @@ describe("delete handler", () => {
     expect(storage.delete).not.toHaveBeenCalled()
   })
 
+  it("returns 400 when fileId is malformed URL encoding", async () => {
+    const storage = stubStorage()
+    userConfig = { storage }
+    const handler = await callHandler()
+    await expect(handler(fakeEvent("%E0%A4%A"))).rejects.toMatchObject({ statusCode: 400 })
+    expect(storage.delete).not.toHaveBeenCalled()
+  })
+
   it("returns 400 when fileId is missing", async () => {
     userConfig = { storage: stubStorage() }
     const handler = await callHandler()

--- a/test/unit/server/download-handler.test.ts
+++ b/test/unit/server/download-handler.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { createError } from "h3"
+import type { StorageAdapter, UploadServerConfig } from "../../../src/runtime/server/types"
+
+let userConfig: UploadServerConfig
+
+vi.mock("#upload-kit-user-config", () => ({
+  get default() {
+    return userConfig
+  },
+}))
+
+const stubStorage = (): StorageAdapter & { presignDownload: ReturnType<typeof vi.fn> } => ({
+  id: "stub",
+  presignUpload: vi.fn(),
+  presignDownload: vi.fn(async (key: string) => ({ downloadUrl: `https://signed/${key}` })),
+})
+
+const callHandler = async () => {
+  const mod = await import("../../../src/runtime/server/handlers/download")
+  return mod.default
+}
+
+const fakeEvent = (fileId: string) =>
+  ({
+    node: { req: { method: "GET", headers: {} } },
+    context: { params: { fileId } },
+  }) as unknown as Parameters<Awaited<ReturnType<typeof callHandler>>>[0]
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+describe("download handler", () => {
+  it("authorizes, then presigns a download URL", async () => {
+    const storage = stubStorage()
+    const authorize = vi.fn(async () => ({ userId: "u1" }))
+    userConfig = { storage, authorize }
+
+    const handler = await callHandler()
+    const result = await handler(fakeEvent("uploads%2Fabc.png"))
+
+    expect(authorize).toHaveBeenCalledWith(expect.anything(), { type: "presign-download", key: "uploads/abc.png" })
+    expect(storage.presignDownload).toHaveBeenCalledWith("uploads/abc.png", expect.objectContaining({ auth: { userId: "u1" } }))
+    expect(result).toEqual({ downloadUrl: "https://signed/uploads/abc.png" })
+  })
+
+  it("propagates authorize errors before presigning", async () => {
+    const storage = stubStorage()
+    userConfig = {
+      storage,
+      authorize: async () => {
+        throw createError({ statusCode: 403, message: "nope" })
+      },
+    }
+
+    const handler = await callHandler()
+    await expect(handler(fakeEvent("abc"))).rejects.toMatchObject({ statusCode: 403 })
+    expect(storage.presignDownload).not.toHaveBeenCalled()
+  })
+
+  it("returns 400 when fileId is missing", async () => {
+    userConfig = { storage: stubStorage() }
+    const handler = await callHandler()
+    await expect(
+      handler({ node: { req: { method: "GET", headers: {} } }, context: { params: {} } } as never),
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it("returns 501 when the adapter doesn't implement presignDownload", async () => {
+    userConfig = { storage: { id: "stub", presignUpload: vi.fn() } }
+    const handler = await callHandler()
+    await expect(handler(fakeEvent("abc"))).rejects.toMatchObject({ statusCode: 501 })
+  })
+
+  it("returns 500 when storage is not configured", async () => {
+    userConfig = {}
+    const handler = await callHandler()
+    await expect(handler(fakeEvent("abc"))).rejects.toMatchObject({ statusCode: 500 })
+  })
+})

--- a/test/unit/server/download-handler.test.ts
+++ b/test/unit/server/download-handler.test.ts
@@ -59,6 +59,14 @@ describe("download handler", () => {
     expect(storage.presignDownload).not.toHaveBeenCalled()
   })
 
+  it("returns 400 when fileId is malformed URL encoding", async () => {
+    const storage = stubStorage()
+    userConfig = { storage }
+    const handler = await callHandler()
+    await expect(handler(fakeEvent("%E0%A4%A"))).rejects.toMatchObject({ statusCode: 400 })
+    expect(storage.presignDownload).not.toHaveBeenCalled()
+  })
+
   it("returns 400 when fileId is missing", async () => {
     userConfig = { storage: stubStorage() }
     const handler = await callHandler()


### PR DESCRIPTION
## Summary

Rounds out CRUD for the v0.2 server half (part of #179, closes #185):

- `GET /api/_upload/download/:fileId` — runs `authorize({ type: "presign-download", key })`, returns `{ downloadUrl }` via the adapter's SDK presigner.
- `DELETE /api/_upload/:fileId` — runs `authorize({ type: "delete", key })`, `hooks.beforeDelete`, then `storage.delete`.

`:fileId` is URL-decoded so clients can pass slashy S3 keys like `uploads/<id>`. 501 is returned when an adapter doesn't implement the op. `useServerUpload().presignDownload` / `.delete` were already exposed by the #189 scaffold.

## Test plan

- [x] `pnpm test` — 427 passing, includes new handler tests covering auth ordering, hook propagation, and 400/500/501 branches
- [x] `pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Users can now download files by providing a file ID
* Users can now delete uploaded files by providing a file ID
* Both operations include built-in authorization validation to control access
* Custom processing hooks are available for extending functionality at key stages

## Tests
* Comprehensive unit test coverage added for download and deletion operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->