### PR TITLE
feat(v0.2): direct upload endpoint and server mode (#184)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "peerDependencies": {
     "@aws-sdk/client-s3": "^3.0.0",
+    "@aws-sdk/lib-storage": "^3.0.0",
     "@aws-sdk/s3-request-presigner": "^3.0.0",
     "@azure/storage-file-datalake": "^12.0.0",
     "@ffmpeg/ffmpeg": "^0.12.0",
@@ -100,6 +101,9 @@
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-s3": {
+      "optional": true
+    },
+    "@aws-sdk/lib-storage": {
       "optional": true
     },
     "@aws-sdk/s3-request-presigner": {

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,31 +1,47 @@
 <script setup lang="ts">
-const uploader = useUploadKit({
+const mode = ref<"presigned" | "server">("presigned")
+
+const presignedUploader = useUploadKit({
+  mode: "presigned",
   maxFiles: 5,
   maxFileSize: 10 * 1024 * 1024,
   thumbnails: true,
 })
 
+const serverUploader = useUploadKit({
+  mode: "server",
+  maxFiles: 5,
+  maxFileSize: 10 * 1024 * 1024,
+  thumbnails: true,
+})
+
+const uploader = computed(() => (mode.value === "server" ? serverUploader : presignedUploader))
+
 const onFileSelect = async (event: Event) => {
   const input = event.target as HTMLInputElement
-  if (input.files) await uploader.addFiles(Array.from(input.files))
+  if (input.files) await uploader.value.addFiles(Array.from(input.files))
+  input.value = ""
 }
-
-uploader.on("file:added", (file) => {
-  console.log("file:added", file.name)
-})
-
-uploader.on("upload:complete", (files) => {
-  console.log("upload:complete", files.length)
-})
 </script>
 
 <template>
   <div class="p-8 max-w-2xl mx-auto">
     <h1 class="text-2xl font-bold mb-2">Nuxt Upload Kit Playground</h1>
-    <p class="text-sm text-gray-500 mb-6">
-      Default <code>useUploadKit()</code> uses the auto-mounted <code>/api/_upload/presign</code> endpoint backed by
-      <code>~~/server/upload.server.config.ts</code>.
+    <p class="text-sm text-gray-500 mb-4">
+      Toggle between <code>mode: "presigned"</code> (client → signed URL → storage) and <code>mode: "server"</code> (client →
+      <code>/api/_upload/direct</code> → storage).
     </p>
+
+    <div class="mb-6 flex gap-4 text-sm">
+      <label class="flex items-center gap-2">
+        <input v-model="mode" type="radio" value="presigned" />
+        presigned
+      </label>
+      <label class="flex items-center gap-2">
+        <input v-model="mode" type="radio" value="server" />
+        server
+      </label>
+    </div>
 
     <div class="mb-6">
       <input
@@ -38,7 +54,7 @@ uploader.on("upload:complete", (files) => {
     </div>
 
     <div v-if="uploader.files.length > 0" class="space-y-4">
-      <h2 class="text-lg font-semibold">Files ({{ uploader.files.length }})</h2>
+      <h2 class="text-lg font-semibold">Files ({{ uploader.files.length }}) · mode: {{ mode }}</h2>
 
       <div v-for="file in uploader.files" :key="file.id" class="flex items-center gap-4 p-4 border rounded-lg">
         <img

--- a/src/module.ts
+++ b/src/module.ts
@@ -107,6 +107,12 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     addServerHandler({
+      route: `${handlerRoute}/direct`,
+      method: "post",
+      handler: resolver.resolve("./runtime/server/handlers/direct"),
+    })
+
+    addServerHandler({
       route: `${handlerRoute}/download/:fileId`,
       method: "get",
       handler: resolver.resolve("./runtime/server/handlers/download"),

--- a/src/runtime/composables/useUploadKit/index.ts
+++ b/src/runtime/composables/useUploadKit/index.ts
@@ -16,6 +16,7 @@ import type {
 import { ValidatorAllowedFileTypes, ValidatorMaxFileSize, ValidatorMaxFiles } from "./validators"
 import { PluginThumbnailGenerator, PluginImageCompressor } from "./plugins"
 import { PluginPresignedHttp } from "./plugins/storage/presigned-http"
+import { PluginServerUpload } from "./plugins/storage/server-upload"
 import { createPluginContext, createFileError, getExtension, setupInitialFiles } from "./utils"
 import { createPluginRunner } from "./plugin-runner"
 import { createFileOperations } from "./file-operations"
@@ -72,9 +73,11 @@ export const useUploadKit = <TUploadResult = unknown>(
   let defaultTransport: StoragePlugin<TUploadResult, any> | null = null
   const getStoragePlugin = (): StoragePlugin<TUploadResult, any> | null => {
     if (options.storage) return options.storage as StoragePlugin<TUploadResult, any>
-    defaultTransport ??= PluginPresignedHttp({
-      endpoint: options.endpoint ?? resolveDefaultEndpoint(),
-    }) as unknown as StoragePlugin<TUploadResult, any>
+    if (!defaultTransport) {
+      const endpoint = options.endpoint ?? resolveDefaultEndpoint()
+      const factory = options.mode === "server" ? PluginServerUpload : PluginPresignedHttp
+      defaultTransport = factory({ endpoint }) as unknown as StoragePlugin<TUploadResult, any>
+    }
     return defaultTransport
   }
 

--- a/src/runtime/composables/useUploadKit/plugins/storage/server-upload.ts
+++ b/src/runtime/composables/useUploadKit/plugins/storage/server-upload.ts
@@ -1,0 +1,82 @@
+import { defineStorageAdapter, type StandaloneUploadOptions } from "../../types"
+
+export interface ServerUploadOptions {
+  /** Mount path of the auto-mounted upload endpoints. Defaults to the module's `handlerRoute`. */
+  endpoint: string
+}
+
+export interface ServerUploadResult {
+  url: string
+  storageKey: string
+}
+
+const postMultipartWithProgress = (
+  url: string,
+  data: Blob | File,
+  filename: string,
+  contentType: string,
+  onProgress: (percentage: number) => void,
+): Promise<{ publicUrl: string; fileId: string }> =>
+  new Promise((resolve, reject) => {
+    const form = new FormData()
+    form.append("file", new Blob([data], { type: contentType }), filename)
+
+    const xhr = new XMLHttpRequest()
+    xhr.upload.addEventListener("progress", (event) => {
+      if (event.lengthComputable) onProgress(Math.round((event.loaded / event.total) * 100))
+    })
+    xhr.addEventListener("load", () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          resolve(JSON.parse(xhr.responseText))
+        } catch (err) {
+          reject(new Error(`[server-upload] failed to parse response: ${(err as Error).message}`))
+        }
+      } else {
+        reject(new Error(`[server-upload] ${url} returned ${xhr.status}: ${xhr.statusText} ${xhr.responseText}`))
+      }
+    })
+    xhr.addEventListener("error", () => reject(new Error("Upload failed due to network error")))
+    xhr.addEventListener("abort", () => reject(new Error("Upload was aborted")))
+    xhr.open("POST", url)
+    xhr.send(form)
+  })
+
+/**
+ * Built-in client transport for `mode: "server"`.
+ * POSTs the file as multipart/form-data to `${endpoint}/direct`. The Nitro handler forwards
+ * it to the configured storage adapter server-side. Credentials never leave the server.
+ */
+export const PluginServerUpload = defineStorageAdapter<ServerUploadOptions, ServerUploadResult>((options) => {
+  const directEndpoint = `${options.endpoint.replace(/\/+$/, "")}/direct`
+
+  return {
+    id: "server-upload",
+    async upload(data: Blob | File, storageKey: string, uploadOptions?: StandaloneUploadOptions) {
+      const contentType = uploadOptions?.contentType || "application/octet-stream"
+      const { publicUrl, fileId } = await postMultipartWithProgress(
+        directEndpoint,
+        data,
+        storageKey,
+        contentType,
+        uploadOptions?.onProgress || (() => {}),
+      )
+      return { url: publicUrl, storageKey: fileId }
+    },
+    hooks: {
+      async upload(file, context) {
+        if (file.source !== "local" || file.data === null) {
+          throw new Error("Cannot upload remote file - no local data available")
+        }
+        const { publicUrl, fileId } = await postMultipartWithProgress(
+          directEndpoint,
+          file.data,
+          file.name,
+          file.mimeType,
+          context.onProgress,
+        )
+        return { url: publicUrl, storageKey: fileId }
+      },
+    },
+  }
+})

--- a/src/runtime/composables/useUploadKit/types.ts
+++ b/src/runtime/composables/useUploadKit/types.ts
@@ -210,11 +210,13 @@ export type UploadFile<TUploadResult = unknown> = LocalUploadFile<TUploadResult>
 export interface UploadOptions {
   /**
    * Transport mode. Defaults to "presigned": the client requests a signed URL from the
-   * configured server endpoint, then PUTs the file directly to cloud storage. Server
-   * forwarding (`mode: "server"`) lands in a follow-up.
+   * configured server endpoint, then PUTs the file directly to cloud storage.
+   * `"server"` streams the file through the Nitro server, which forwards to storage using
+   * the configured adapter — use when credentials must stay server-side or server-side
+   * validation/transforms must run before storage.
    * @default "presigned"
    */
-  mode?: "presigned"
+  mode?: "presigned" | "server"
 
   /**
    * Override the auto-mounted upload endpoint path. Defaults to the module's `handlerRoute`

--- a/src/runtime/server/adapters/s3.ts
+++ b/src/runtime/server/adapters/s3.ts
@@ -1,5 +1,7 @@
 import { S3Client, PutObjectCommand, DeleteObjectCommand, GetObjectCommand } from "@aws-sdk/client-s3"
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner"
+import { Upload } from "@aws-sdk/lib-storage"
+import type { Readable } from "node:stream"
 import type { StorageAdapter, PresignedFileInput, ServerHookContext } from "../types"
 
 export interface S3StorageOptions {
@@ -59,6 +61,7 @@ export const S3Storage = (options: S3StorageOptions): StorageAdapter => {
 
   return {
     id: "s3-storage",
+    resolveKey: keyStrategy,
     presignUpload: async (input: PresignedFileInput, _ctx: ServerHookContext) => {
       const key = keyStrategy(input)
       const command = new PutObjectCommand({
@@ -81,6 +84,19 @@ export const S3Storage = (options: S3StorageOptions): StorageAdapter => {
     },
     delete: async (key: string) => {
       await client.send(new DeleteObjectCommand({ Bucket: options.bucket, Key: key }))
+    },
+    put: async (input: { key: string; body: unknown; contentType?: string }) => {
+      const upload = new Upload({
+        client,
+        params: {
+          Bucket: options.bucket,
+          Key: input.key,
+          Body: input.body as Buffer | Uint8Array | Blob | Readable | string,
+          ContentType: input.contentType,
+        },
+      })
+      await upload.done()
+      return { publicUrl: publicUrl(input.key) }
     },
   }
 }

--- a/src/runtime/server/handlers/direct.ts
+++ b/src/runtime/server/handlers/direct.ts
@@ -1,0 +1,65 @@
+import { defineEventHandler, readMultipartFormData, createError } from "h3"
+// @ts-expect-error virtual user-config import
+import userConfig from "#upload-kit-user-config"
+import type { UploadServerConfig, UploadFileDescriptor, ServerHookContext } from "../types"
+
+const config = userConfig as UploadServerConfig
+
+const generateFileId = (file: UploadFileDescriptor): string => {
+  const ts = Date.now()
+  const rand = Math.random().toString(36).slice(2, 10)
+  const dot = file.name.lastIndexOf(".")
+  const ext = dot > 0 ? file.name.slice(dot) : ""
+  return `${ts}-${rand}${ext}`
+}
+
+export default defineEventHandler(async (event) => {
+  if (!config.storage) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Server Misconfigured",
+      message: "No storage adapter configured. Set `storage` in your upload.server.config.ts.",
+    })
+  }
+  if (!config.storage.put) {
+    throw createError({
+      statusCode: 501,
+      statusMessage: "Not Implemented",
+      message: `Storage adapter "${config.storage.id}" does not implement put().`,
+    })
+  }
+
+  const parts = await readMultipartFormData(event)
+  const filePart = parts?.find((p) => p.name === "file" && p.filename)
+  if (!filePart || !filePart.filename || !filePart.data) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request",
+      message: "Expected a multipart body with a `file` part.",
+    })
+  }
+
+  const file: UploadFileDescriptor = {
+    name: filePart.filename,
+    size: filePart.data.length,
+    mimeType: filePart.type || "application/octet-stream",
+  }
+
+  const auth = config.authorize ? await config.authorize(event, { type: "direct-upload", file }) : {}
+  const ctx: ServerHookContext = { event, auth }
+
+  if (config.validators) {
+    for (const validate of config.validators) {
+      await validate(file, ctx)
+    }
+  }
+
+  const fileId = generateFileId(file)
+  const key = config.storage.resolveKey?.({ ...file, fileId }) ?? `uploads/${fileId}`
+
+  const result = await config.storage.put({ key, body: filePart.data, contentType: file.mimeType }, ctx)
+
+  await config.hooks?.afterUpload?.(file, ctx)
+
+  return { publicUrl: result.publicUrl, fileId: key }
+})

--- a/src/runtime/server/types.ts
+++ b/src/runtime/server/types.ts
@@ -53,6 +53,11 @@ export interface StorageAdapter {
   delete?: (key: string, ctx: ServerHookContext) => Promise<void>
   put?: (input: { key: string; body: unknown; contentType?: string }, ctx: ServerHookContext) => Promise<{ publicUrl: string }>
   list?: (prefix: string | undefined, ctx: ServerHookContext) => Promise<Array<{ key: string; size: number }>>
+  /**
+   * Resolve the final storage key for a given file descriptor using the adapter's keyStrategy.
+   * Used by the /direct handler so direct uploads share the same key resolution as presigned uploads.
+   */
+  resolveKey?: (input: PresignedFileInput) => string
 }
 
 /**

--- a/test/unit/server/direct-handler.test.ts
+++ b/test/unit/server/direct-handler.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { createError } from "h3"
+import type { StorageAdapter, UploadServerConfig } from "../../../src/runtime/server/types"
+
+let userConfig: UploadServerConfig
+
+vi.mock("#upload-kit-user-config", () => ({
+  get default() {
+    return userConfig
+  },
+}))
+
+const stubStorage = (): StorageAdapter & {
+  put: ReturnType<typeof vi.fn>
+  resolveKey: ReturnType<typeof vi.fn>
+} => ({
+  id: "stub",
+  presignUpload: vi.fn(),
+  resolveKey: vi.fn((input) => `uploads/${input.fileId}`),
+  put: vi.fn(async (input) => ({ publicUrl: `https://cdn/${input.key}` })),
+})
+
+const callHandler = async () => {
+  const mod = await import("../../../src/runtime/server/handlers/direct")
+  return mod.default
+}
+
+const fakeEvent = () =>
+  ({
+    node: { req: { method: "POST", headers: { "content-type": "multipart/form-data" } } },
+    context: {},
+  }) as unknown as Parameters<Awaited<ReturnType<typeof callHandler>>>[0]
+
+const mockMultipart = (parts: Array<{ name: string; filename?: string; type?: string; data: Buffer }>) => {
+  vi.doMock("h3", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("h3")>()
+    return { ...actual, readMultipartFormData: async () => parts }
+  })
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.doUnmock("h3")
+})
+
+describe("direct handler", () => {
+  it("authorizes, validates, puts, then runs afterUpload", async () => {
+    const order: string[] = []
+    const storage = stubStorage()
+    storage.put.mockImplementation(async (input) => {
+      order.push("put")
+      return { publicUrl: `https://cdn/${input.key}` }
+    })
+    userConfig = {
+      storage,
+      authorize: vi.fn(async () => {
+        order.push("authorize")
+        return { userId: "u1" }
+      }),
+      validators: [
+        () => {
+          order.push("validate")
+        },
+      ],
+      hooks: {
+        afterUpload: vi.fn(async () => {
+          order.push("afterUpload")
+        }),
+      },
+    }
+
+    mockMultipart([{ name: "file", filename: "photo.png", type: "image/png", data: Buffer.from("pixels") }])
+
+    const handler = await callHandler()
+    const result = await handler(fakeEvent())
+
+    expect(order).toEqual(["authorize", "validate", "put", "afterUpload"])
+    expect(storage.resolveKey).toHaveBeenCalled()
+    expect(storage.put).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.any(Buffer), contentType: "image/png", key: expect.stringMatching(/^uploads\//) }),
+      expect.objectContaining({ auth: { userId: "u1" } }),
+    )
+    expect(result).toMatchObject({
+      publicUrl: expect.stringMatching(/^https:\/\/cdn\//),
+      fileId: expect.stringMatching(/^uploads\//),
+    })
+  })
+
+  it("propagates validator errors before putting", async () => {
+    const storage = stubStorage()
+    userConfig = {
+      storage,
+      validators: [
+        () => {
+          throw createError({ statusCode: 413, message: "too big" })
+        },
+      ],
+    }
+
+    mockMultipart([{ name: "file", filename: "big.bin", type: "application/octet-stream", data: Buffer.from("x") }])
+    const handler = await callHandler()
+    await expect(handler(fakeEvent())).rejects.toMatchObject({ statusCode: 413 })
+    expect(storage.put).not.toHaveBeenCalled()
+  })
+
+  it("propagates authorize errors before putting", async () => {
+    const storage = stubStorage()
+    userConfig = {
+      storage,
+      authorize: async () => {
+        throw createError({ statusCode: 401, message: "nope" })
+      },
+    }
+
+    mockMultipart([{ name: "file", filename: "f.bin", type: "application/octet-stream", data: Buffer.from("x") }])
+    const handler = await callHandler()
+    await expect(handler(fakeEvent())).rejects.toMatchObject({ statusCode: 401 })
+    expect(storage.put).not.toHaveBeenCalled()
+  })
+
+  it("rejects when multipart has no file part", async () => {
+    userConfig = { storage: stubStorage() }
+    mockMultipart([{ name: "notfile", data: Buffer.from("x") }])
+    const handler = await callHandler()
+    await expect(handler(fakeEvent())).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it("returns 501 when the adapter does not implement put", async () => {
+    userConfig = { storage: { id: "stub", presignUpload: vi.fn() } }
+    mockMultipart([{ name: "file", filename: "f.bin", type: "application/octet-stream", data: Buffer.from("x") }])
+    const handler = await callHandler()
+    await expect(handler(fakeEvent())).rejects.toMatchObject({ statusCode: 501 })
+  })
+
+  it("returns 500 when storage is not configured", async () => {
+    userConfig = {}
+    mockMultipart([{ name: "file", filename: "f.bin", type: "application/octet-stream", data: Buffer.from("x") }])
+    const handler = await callHandler()
+    await expect(handler(fakeEvent())).rejects.toMatchObject({ statusCode: 500 })
+  })
+
+  it("falls back to uploads/{fileId} when adapter has no resolveKey", async () => {
+    const storage: StorageAdapter & { put: ReturnType<typeof vi.fn> } = {
+      id: "stub",
+      presignUpload: vi.fn(),
+      put: vi.fn(async (input) => ({ publicUrl: `https://cdn/${input.key}` })),
+    }
+    userConfig = { storage }
+    mockMultipart([{ name: "file", filename: "a.png", type: "image/png", data: Buffer.from("pix") }])
+    const handler = await callHandler()
+    const result = await handler(fakeEvent())
+    expect(storage.put).toHaveBeenCalledWith(
+      expect.objectContaining({ key: expect.stringMatching(/^uploads\//) }),
+      expect.anything(),
+    )
+    expect(result.fileId).toMatch(/^uploads\//)
+  })
+})

--- a/test/unit/server/s3-adapter.test.ts
+++ b/test/unit/server/s3-adapter.test.ts
@@ -53,6 +53,16 @@ describe("S3Storage", () => {
     ).rejects.toThrow(/forcePathStyle/)
   })
 
+  it("exposes resolveKey mirroring the keyStrategy", () => {
+    const storage = S3Storage({
+      bucket: "b",
+      region: "us-east-1",
+      credentials: { accessKeyId: "x", secretAccessKey: "y" },
+      keyStrategy: ({ fileId }) => `tenant-7/${fileId}`,
+    })
+    expect(storage.resolveKey?.({ fileId: "abc", name: "abc", size: 1, mimeType: "text/plain" })).toBe("tenant-7/abc")
+  })
+
   it("uses path-style URLs for S3-compatible endpoints", async () => {
     const storage = S3Storage({
       bucket: "minio-bucket",


### PR DESCRIPTION
## Summary

- Adds `POST /api/_upload/direct` Nitro handler: parses multipart, runs `authorize({ type: "direct-upload", file })` → server validators → `storage.put` → `hooks.afterUpload`. Returns `{ publicUrl, fileId }`.
- Adds client `mode: "server"` in \`useUploadKit\` backed by a new \`PluginServerUpload\` transport that POSTs multipart to \`/direct\` with XHR progress tracking.
- S3 adapter gains a \`put\` built on \`@aws-sdk/lib-storage\` \`Upload\` (SDK-native multipart/retry) and a \`resolveKey\` so direct and presigned uploads share key resolution. \`@aws-sdk/lib-storage\` added as optional peer dep.
- Playground gets a presigned/server radio toggle. Unit tests cover the handler flow, error paths, 500/501, \`resolveKey\` fallback, and the new S3 method.

Closes #184.

## Test plan

- [x] \`pnpm test\` — 437 tests pass (7 new direct-handler + 1 S3 resolveKey)
- [x] \`pnpm lint\` clean
- [ ] Manual: playground toggle, upload via both modes, confirm object lands in bucket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "server" upload mode that streams files through the Nitro server before forwarding to storage.
  * S3 adapter now supports direct uploads via the new `put` method.

* **Chores**
  * Added `@aws-sdk/lib-storage` as an optional peer dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->