### PR TITLE
feat(v0.2): maxBodySize cap on /direct upload endpoint

### DIFF
--- a/src/runtime/server/handlers/direct.ts
+++ b/src/runtime/server/handlers/direct.ts
@@ -1,4 +1,4 @@
-import { defineEventHandler, readMultipartFormData, createError } from "h3"
+import { defineEventHandler, readMultipartFormData, createError, getRequestHeader } from "h3"
 // @ts-expect-error virtual user-config import
 import userConfig from "#upload-kit-user-config"
 import type { UploadServerConfig, UploadFileDescriptor, ServerHookContext } from "../types"
@@ -27,6 +27,17 @@ export default defineEventHandler(async (event) => {
       statusMessage: "Not Implemented",
       message: `Storage adapter "${config.storage.id}" does not implement put().`,
     })
+  }
+
+  if (config.maxBodySize != null) {
+    const contentLength = Number(getRequestHeader(event, "content-length"))
+    if (Number.isFinite(contentLength) && contentLength > config.maxBodySize) {
+      throw createError({
+        statusCode: 413,
+        statusMessage: "Payload Too Large",
+        message: `Request body exceeds maxBodySize (${config.maxBodySize} bytes).`,
+      })
+    }
   }
 
   const parts = await readMultipartFormData(event)

--- a/src/runtime/server/types.ts
+++ b/src/runtime/server/types.ts
@@ -72,6 +72,13 @@ export interface UploadServerConfig {
   storage?: StorageAdapter
   authorize?: (event: H3Event, op: AuthorizeOp) => AuthorizeContext | Promise<AuthorizeContext>
   validators?: ServerValidator[]
+  /**
+   * Maximum request body size (in bytes) accepted by the `/direct` upload endpoint.
+   * Enforced against the `Content-Length` header before the body is read into memory,
+   * so authorize/validators never see oversized requests. Rely on an upstream
+   * proxy/CDN request-size cap for chunked transfer encoding, which has no Content-Length.
+   */
+  maxBodySize?: number
   hooks?: {
     beforePresign?: (file: UploadFileDescriptor, ctx: ServerHookContext) => void | Promise<void>
     afterUpload?: (file: UploadFileDescriptor, ctx: ServerHookContext) => void | Promise<void>

--- a/test/unit/server/direct-handler.test.ts
+++ b/test/unit/server/direct-handler.test.ts
@@ -25,16 +25,21 @@ const callHandler = async () => {
   return mod.default
 }
 
-const fakeEvent = () =>
+const fakeEvent = (headers: Record<string, string> = {}) =>
   ({
-    node: { req: { method: "POST", headers: { "content-type": "multipart/form-data" } } },
+    node: { req: { method: "POST", headers: { "content-type": "multipart/form-data", ...headers } } },
     context: {},
   }) as unknown as Parameters<Awaited<ReturnType<typeof callHandler>>>[0]
 
 const mockMultipart = (parts: Array<{ name: string; filename?: string; type?: string; data: Buffer }>) => {
   vi.doMock("h3", async (importOriginal) => {
     const actual = await importOriginal<typeof import("h3")>()
-    return { ...actual, readMultipartFormData: async () => parts }
+    return {
+      ...actual,
+      readMultipartFormData: async () => parts,
+      getRequestHeader: (event: { node: { req: { headers: Record<string, string> } } }, name: string) =>
+        event.node.req.headers[name.toLowerCase()],
+    }
   })
 }
 
@@ -137,6 +142,28 @@ describe("direct handler", () => {
     mockMultipart([{ name: "file", filename: "f.bin", type: "application/octet-stream", data: Buffer.from("x") }])
     const handler = await callHandler()
     await expect(handler(fakeEvent())).rejects.toMatchObject({ statusCode: 500 })
+  })
+
+  it("rejects with 413 when Content-Length exceeds maxBodySize, before authorize/read", async () => {
+    const storage = stubStorage()
+    const authorize = vi.fn(async () => ({}))
+    userConfig = { storage, authorize, maxBodySize: 100 }
+
+    mockMultipart([{ name: "file", filename: "big.bin", type: "application/octet-stream", data: Buffer.from("x") }])
+    const handler = await callHandler()
+    await expect(handler(fakeEvent({ "content-length": "500" }))).rejects.toMatchObject({ statusCode: 413 })
+    expect(authorize).not.toHaveBeenCalled()
+    expect(storage.put).not.toHaveBeenCalled()
+  })
+
+  it("passes when Content-Length is within maxBodySize", async () => {
+    const storage = stubStorage()
+    userConfig = { storage, maxBodySize: 1000 }
+
+    mockMultipart([{ name: "file", filename: "small.png", type: "image/png", data: Buffer.from("pix") }])
+    const handler = await callHandler()
+    const result = await handler(fakeEvent({ "content-length": "50" }))
+    expect(result.fileId).toMatch(/^uploads\//)
   })
 
   it("falls back to uploads/{fileId} when adapter has no resolveKey", async () => {


### PR DESCRIPTION
## Summary
- Adds `maxBodySize` option to `UploadServerConfig`, enforced against `Content-Length` in the `/direct` handler before `readMultipartFormData` runs — so authorize/validators never see oversized requests and oversized bodies are rejected with 413 without being buffered.
- Chunked transfer encoding (no `Content-Length`) is not covered; upstream proxy/CDN caps remain the defense there. Streaming the body to the adapter (option 3 in the issue) is a larger follow-up.

Closes #195.

## Test plan
- [x] `pnpm test` (449 passing, includes two new cases: over-cap rejects with 413 before authorize; under-cap passes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `maxBodySize` configuration setting for direct uploads to limit request sizes.
  * Requests exceeding the configured size limit are now validated and rejected with a 413 error response before further processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->