### PR TITLE
feat: server-side enforcement of aggregate restrictions (#203)

### DIFF
--- a/docs/content/1.get-started/2.configuration.md
+++ b/docs/content/1.get-started/2.configuration.md
@@ -185,6 +185,28 @@ export default defineNuxtConfig({
 })
 ```
 
+### Server-side aggregate enforcement
+
+Per-file rules (`maxFileSize`, `minFileSize`, `allowedMimeTypes`, `disallowedMimeTypes`) are enforced on both the client and server automatically. Aggregate rules (`maxFiles`, `maxTotalSize`) depend on user-level state the server doesn't have — by default they're client-side UX only and a hostile client can bypass them.
+
+To enforce aggregate rules server-side, provide `getExistingState` in `server/upload.server.config.ts`:
+
+```ts [server/upload.server.config.ts]
+export default defineUploadServerConfig({
+  storage: S3Storage({ bucket: env.S3_BUCKET, region: env.AWS_REGION }),
+  authorize: async (event) => ({ userId: event.context.user.id }),
+  getExistingState: async (ctx) => {
+    const files = await db.files.findMany({ where: { userId: ctx.auth.userId } })
+    return {
+      count: files.length,
+      totalSize: files.reduce((sum, f) => sum + f.size, 0),
+    }
+  },
+})
+```
+
+The hook runs after `authorize`, so `ctx.auth` is available for scoping the lookup. Return the user's _existing_ totals (excluding the file being added by the current request) — the rule engine accounts for the incoming file itself.
+
 ### Per-instance overrides
 
 Pass a `restrictions` object to `useUploadKit` when a specific component needs to be stricter than the app-wide defaults:
@@ -300,6 +322,7 @@ export default defineUploadServerConfig({
 | `validators`  | `ServerValidator[]`                             | Custom server-side checks (DB quotas, magic-byte sniffing). Run after `authorize` and after declarative `restrictions` have passed. See [Validation](/plugins/validators).               |
 | `hooks`       | `{ beforePresign, afterUpload, beforeDelete }`  | Side-effect hooks for audit, instrumentation, downstream fanout. Don't throw to reject — use `validators` for that.                                                                      |
 | `maxBodySize` | `number`                                        | Max bytes accepted by the `/direct` endpoint (server mode only). Enforced via `Content-Length` before the body is read.                                                                  |
+| `getExistingState` | `(ctx) => { count, totalSize }`            | Resolves the caller's existing upload state so the server can enforce aggregate restrictions (`maxFiles`, `maxTotalSize`). Runs after `authorize`. Without it, only per-file rules are enforced server-side. |
 
 ## Complete Example
 

--- a/src/runtime/server/handlers/direct.ts
+++ b/src/runtime/server/handlers/direct.ts
@@ -38,10 +38,11 @@ export default defineEventHandler(async (event) => {
     mimeType: filePart.type || "application/octet-stream",
   }
 
-  enforceRestrictions(file, getRestrictions())
-
   const auth = config.authorize ? await config.authorize(event, { type: "direct-upload", file }) : {}
   const ctx: ServerHookContext = { event, auth }
+
+  const state = config.getExistingState ? await config.getExistingState(ctx) : undefined
+  enforceRestrictions(file, getRestrictions(), state)
 
   if (config.validators) {
     for (const validate of config.validators) await validate(file, ctx)

--- a/src/runtime/server/handlers/presign.ts
+++ b/src/runtime/server/handlers/presign.ts
@@ -35,10 +35,11 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  enforceRestrictions(file, getRestrictions())
-
   const auth = config.authorize ? await config.authorize(event, { type: "presign-upload", file }) : {}
   const ctx: ServerHookContext = { event, auth }
+
+  const state = config.getExistingState ? await config.getExistingState(ctx) : undefined
+  enforceRestrictions(file, getRestrictions(), state)
 
   if (config.validators) {
     for (const validate of config.validators) await validate(file, ctx)

--- a/src/runtime/server/restrictions.ts
+++ b/src/runtime/server/restrictions.ts
@@ -1,6 +1,6 @@
 import { createError } from "h3"
-import { applyFileRestrictions, type Restrictions, type RestrictionCode } from "../shared"
-import type { UploadFileDescriptor } from "./types"
+import { applyFileRestrictions, applyRestrictions, type Restrictions, type RestrictionCode } from "../shared"
+import type { ExistingUploadState, UploadFileDescriptor } from "./types"
 
 const STATUS_BY_CODE: Record<RestrictionCode, { code: number; statusMessage: string }> = {
   "max-file-size": { code: 413, statusMessage: "Payload Too Large" },
@@ -12,13 +12,23 @@ const STATUS_BY_CODE: Record<RestrictionCode, { code: number; statusMessage: str
 }
 
 /**
- * Enforce the shared per-file restrictions against an incoming file descriptor.
+ * Enforce shared restrictions against an incoming file descriptor.
  * Throws an h3 error with a status code derived from the violation type.
- * The caller passes the restrictions resolved from `runtimeConfig.public.uploadKit.restrictions`.
+ *
+ * When `state` is provided (resolved from `getExistingState`), aggregate rules
+ * (`maxFiles`, `maxTotalSize`) are enforced too. Without it, only per-file rules
+ * are checked, since the server is otherwise stateless per request.
  */
-export function enforceRestrictions(file: UploadFileDescriptor, restrictions: Restrictions | undefined): void {
+export function enforceRestrictions(
+  file: UploadFileDescriptor,
+  restrictions: Restrictions | undefined,
+  state?: ExistingUploadState,
+): void {
   if (!restrictions) return
-  const violation = applyFileRestrictions({ name: file.name, size: file.size, type: file.mimeType }, restrictions)
+  const descriptor = { name: file.name, size: file.size, type: file.mimeType }
+  const violation = state
+    ? applyRestrictions(descriptor, { existingCount: state.count, existingTotalSize: state.totalSize }, restrictions)
+    : applyFileRestrictions(descriptor, restrictions)
   if (!violation) return
   const { code, statusMessage } = STATUS_BY_CODE[violation.code]
   throw createError({

--- a/src/runtime/server/types.ts
+++ b/src/runtime/server/types.ts
@@ -72,6 +72,15 @@ export interface StorageAdapter {
  */
 export type ServerValidator = (file: UploadFileDescriptor, ctx: ServerHookContext) => void | Promise<void>
 
+/**
+ * Existing per-user upload state used to enforce aggregate restrictions
+ * (`maxFiles`, `maxTotalSize`) on the server. Returned by `getExistingState`.
+ */
+export interface ExistingUploadState {
+  count: number
+  totalSize: number
+}
+
 export interface UploadServerConfig {
   storage?: StorageAdapter
   authorize?: (event: H3Event, op: AuthorizeOp) => AuthorizeContext | Promise<AuthorizeContext>
@@ -93,6 +102,16 @@ export interface UploadServerConfig {
    * proxy/CDN request-size cap for chunked transfer encoding, which has no Content-Length.
    */
   maxBodySize?: number
+  /**
+   * Resolve the caller's existing upload state (count + total size) so the server
+   * can enforce aggregate restrictions (`maxFiles`, `maxTotalSize`) statefully.
+   * Runs after `authorize`, so `ctx.auth` is available for scoping the lookup
+   * (typically a DB query keyed by `ctx.auth.userId`).
+   *
+   * Without this hook the server only enforces per-file rules; aggregate rules
+   * remain client-side UX and can be bypassed by a hostile client.
+   */
+  getExistingState?: (ctx: ServerHookContext) => ExistingUploadState | Promise<ExistingUploadState>
   hooks?: {
     beforePresign?: (file: UploadFileDescriptor, ctx: ServerHookContext) => void | Promise<void>
     afterUpload?: (file: UploadFileDescriptor, ctx: ServerHookContext) => void | Promise<void>

--- a/test/unit/server/direct-handler.test.ts
+++ b/test/unit/server/direct-handler.test.ts
@@ -179,6 +179,53 @@ describe("direct handler", () => {
     expect(result.fileId).toMatch(/^uploads\//)
   })
 
+  it("enforces maxFiles using getExistingState (409)", async () => {
+    const storage = stubStorage()
+    userConfig = {
+      storage,
+      authorize: async () => ({ userId: "u1" }),
+      getExistingState: async () => ({ count: 10, totalSize: 0 }),
+    }
+
+    const { __setRuntimeConfig } = await import("../../fixtures/nuxt-imports")
+    __setRuntimeConfig({ uploadKit: { restrictions: { maxFiles: 10 } } })
+
+    mockMultipart([{ name: "file", filename: "a.png", type: "image/png", data: Buffer.from("pix") }])
+    const handler = await callHandler()
+    await expect(handler(fakeEvent())).rejects.toMatchObject({ statusCode: 409 })
+    expect(storage.put).not.toHaveBeenCalled()
+  })
+
+  it("enforces maxTotalSize using getExistingState (413)", async () => {
+    const storage = stubStorage()
+    userConfig = {
+      storage,
+      authorize: async () => ({ userId: "u1" }),
+      getExistingState: async () => ({ count: 0, totalSize: 900 }),
+    }
+
+    const { __setRuntimeConfig } = await import("../../fixtures/nuxt-imports")
+    __setRuntimeConfig({ uploadKit: { restrictions: { maxTotalSize: 1000 } } })
+
+    mockMultipart([{ name: "file", filename: "a.png", type: "image/png", data: Buffer.alloc(200) }])
+    const handler = await callHandler()
+    await expect(handler(fakeEvent())).rejects.toMatchObject({ statusCode: 413 })
+    expect(storage.put).not.toHaveBeenCalled()
+  })
+
+  it("skips aggregate rules when getExistingState is not provided", async () => {
+    const storage = stubStorage()
+    userConfig = { storage }
+
+    const { __setRuntimeConfig } = await import("../../fixtures/nuxt-imports")
+    __setRuntimeConfig({ uploadKit: { restrictions: { maxFiles: 1, maxTotalSize: 10 } } })
+
+    mockMultipart([{ name: "file", filename: "a.png", type: "image/png", data: Buffer.from("pix") }])
+    const handler = await callHandler()
+    const result = await handler(fakeEvent())
+    expect(result.fileId).toMatch(/^uploads\//)
+  })
+
   it("falls back to uploads/{fileId} when adapter has no resolveKey", async () => {
     const storage: StorageAdapter & { put: ReturnType<typeof vi.fn> } = {
       id: "stub",

--- a/test/unit/server/presign-handler.test.ts
+++ b/test/unit/server/presign-handler.test.ts
@@ -184,6 +184,99 @@ describe("presign handler", () => {
     expect(storage.presignUpload).not.toHaveBeenCalled()
   })
 
+  it("enforces maxFiles using getExistingState (409)", async () => {
+    const storage = stubStorage()
+    userConfig = {
+      storage,
+      authorize: async () => ({ userId: "u1" }),
+      getExistingState: async () => ({ count: 10, totalSize: 0 }),
+    }
+
+    const { __setRuntimeConfig } = await import("../../fixtures/nuxt-imports")
+    __setRuntimeConfig({ uploadKit: { restrictions: { maxFiles: 10 } } })
+
+    vi.doMock("h3", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("h3")>()
+      return { ...actual, readBody: async () => ({ file: { name: "a.png", size: 100, mimeType: "image/png" } }) }
+    })
+
+    const handler = await callHandler()
+    await expect(handler(fakeEvent({}))).rejects.toMatchObject({ statusCode: 409 })
+    expect(storage.presignUpload).not.toHaveBeenCalled()
+  })
+
+  it("enforces maxTotalSize using getExistingState (413)", async () => {
+    const storage = stubStorage()
+    userConfig = {
+      storage,
+      authorize: async () => ({ userId: "u1" }),
+      getExistingState: async () => ({ count: 0, totalSize: 900 }),
+    }
+
+    const { __setRuntimeConfig } = await import("../../fixtures/nuxt-imports")
+    __setRuntimeConfig({ uploadKit: { restrictions: { maxTotalSize: 1000 } } })
+
+    vi.doMock("h3", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("h3")>()
+      return { ...actual, readBody: async () => ({ file: { name: "a.png", size: 200, mimeType: "image/png" } }) }
+    })
+
+    const handler = await callHandler()
+    await expect(handler(fakeEvent({}))).rejects.toMatchObject({ statusCode: 413 })
+    expect(storage.presignUpload).not.toHaveBeenCalled()
+  })
+
+  it("skips aggregate rules when getExistingState is not provided", async () => {
+    const storage = stubStorage()
+    userConfig = { storage }
+
+    const { __setRuntimeConfig } = await import("../../fixtures/nuxt-imports")
+    __setRuntimeConfig({ uploadKit: { restrictions: { maxFiles: 1, maxTotalSize: 10 } } })
+
+    vi.doMock("h3", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("h3")>()
+      return { ...actual, readBody: async () => ({ file: { name: "a.png", size: 100, mimeType: "image/png" } }) }
+    })
+
+    const handler = await callHandler()
+    const result = await handler(fakeEvent({}))
+    expect(result).toMatchObject({ uploadUrl: expect.any(String) })
+  })
+
+  it("calls getExistingState after authorize, before validators", async () => {
+    const order: string[] = []
+    const storage = stubStorage()
+    userConfig = {
+      storage,
+      authorize: async () => {
+        order.push("authorize")
+        return { userId: "u1" }
+      },
+      getExistingState: async () => {
+        order.push("getExistingState")
+        return { count: 0, totalSize: 0 }
+      },
+      validators: [
+        () => {
+          order.push("validate")
+        },
+      ],
+    }
+    storage.presignUpload.mockImplementation(async (input) => {
+      order.push("presign")
+      return { uploadUrl: "u", publicUrl: "p", fileId: input.fileId }
+    })
+
+    vi.doMock("h3", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("h3")>()
+      return { ...actual, readBody: async () => ({ file: { name: "a.png", size: 1, mimeType: "image/png" } }) }
+    })
+
+    const handler = await callHandler()
+    await handler(fakeEvent({}))
+    expect(order).toEqual(["authorize", "getExistingState", "validate", "presign"])
+  })
+
   it("rejects malformed bodies with 400", async () => {
     userConfig = { storage: stubStorage() }
 


### PR DESCRIPTION
## Summary

Closes #203. Adds optional `getExistingState` hook to `UploadServerConfig` so the `/presign` and `/direct` handlers can enforce `maxFiles` and `maxTotalSize` against per-user state — closing the gap left by #212 where aggregate rules were skipped server-side and only enforced as client UX.

Without the hook, behavior is unchanged (per-file rules only). When provided, the handler runs `authorize` → `getExistingState` → `enforceRestrictions` so `ctx.auth` is available for scoping the lookup.

## Test plan

- [x] Unit tests for presign + direct: 409 (maxFiles), 413 (maxTotalSize), no-op when hook absent, ordering vs authorize/validators
- [x] `pnpm test` — 449 passing
- [x] `pnpm lint` — clean